### PR TITLE
MDS-260 vscode: add recommended extension and setting for the workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ composer.phar
 /vendor/
 atlassian-ide-plugin.xml
 /node_modules/
-/.vscode/
 .eslintignore
 .stylelintignore
 /jsdoc
@@ -49,6 +48,11 @@ phpcs.xml
 jsconfig.json
 UPGRADING-CURRENT.md
 .phpunit.cache
+
+# VSCode
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
 
 /dist/
 /storybook-static/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "eslint.validate": [
+    "typescript",
+    "typescriptreact",
+    "javascript",
+    "javascriptreact"
+  ],
+  "eslint.workingDirectories": [{ "mode": "auto" }]
+}


### PR DESCRIPTION
## What was done
- Added `.vscode/extensions.json` to encourage developers to install Prettier, ESLint, EditorConfig
- Added `.vscode/settings.json` to enable prettier and eslint on every save