### PR TITLE
MDS-239 dependabot: Group updates to reduce PR spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: weekly
     groups:
+      dev-dependencies:
+        patterns:
+          - '*'
       storybook:
         patterns:
           - '@storybook/*'
@@ -12,3 +15,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    groups:
+      actions-deps:
+        patterns:
+          - '*'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
 
 const dirname =
   typeof __dirname !== 'undefined'
@@ -17,14 +17,14 @@ export default defineConfig({
   },
   plugins: isStorybook
     ? [
-      storybookTest({
-        configDir: path.resolve(dirname, '.storybook'),
-        tags: {
-          include: ['test'],
-          exclude: ['experimental'],
-        },
-      }),
-    ]
+        storybookTest({
+          configDir: path.resolve(dirname, '.storybook'),
+          tags: {
+            include: ['test'],
+            exclude: ['experimental'],
+          },
+        }),
+      ]
     : [],
   test: {
     globals: true,
@@ -40,11 +40,11 @@ export default defineConfig({
       : ['**/*.stories.*', '.storybook/**', '**/.storybook/**'],
     browser: isStorybook
       ? {
-        enabled: true,
-        headless: true,
-        provider: playwright({}),
-        instances: [{ browser: 'chromium' }],
-      }
+          enabled: true,
+          headless: true,
+          provider: playwright({}),
+          instances: [{ browser: 'chromium' }],
+        }
       : undefined,
     coverage: {
       provider: 'istanbul',
@@ -59,8 +59,8 @@ export default defineConfig({
       ],
       watermarks: !isStorybook
         ? {
-          statements: [50, 80],
-        }
+            statements: [50, 80],
+          }
         : undefined,
     },
   },


### PR DESCRIPTION
Added grouping to catch updates into 3 different pull requests rather than opening new pull requests for all npm dependency updates besides @storybook updates.

Also ran a format which picked up the vitest file. Might look at adding Husky to add pre-commit linting & formating into the repo.