### PR TITLE
MDS-263 vscode: added recommended extension 'CSS Navigation'

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "EditorConfig.EditorConfig",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "pucelle.vscode-css-navigation"
   ]
 }


### PR DESCRIPTION
## Why
Upon editing/browsing through CSS files and variables, I found the extension `CSS Navigation` pretty handy for VSCode to navigate through variable references. Adding this to the recommended list for other VSCode developers to adopt