### PR TITLE
ci(MDS-238): Add Chromatic

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,9 @@
-name: Run Storybook, Accessibility & JSUnit tests.
+name: Storybook, Accessibility & Chromatic
 on: pull_request
+
+env:
+  NODE_VERSION: 22.13.0
+
 jobs:
   storybook-accessibility:
     runs-on: ubuntu-latest
@@ -13,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22.13.0
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Clean install
         run: |
@@ -31,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22.13.0
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Clean install
         run: |
@@ -42,3 +46,35 @@ jobs:
         run: npm run test-unit-coverage
         env:
           SB_URL: '${{ github.event.deployment_status.environment_url }}'
+
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+        env:
+          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+          CHROMATIC_SLUG: ${{ github.repository }}
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Clean install
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
+          skip: "dependabot/**"
+          autoAcceptChanges: "main"
+          externals: |
+            fonts/**
+            tokens/**

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ UPGRADING-CURRENT.md
 
 /dist/
 /storybook-static/
+build-storybook.log
 /coverage/

--- a/components/src/button/Button.stories.tsx
+++ b/components/src/button/Button.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { act } from 'react';
 import { ThemeProvider } from 'react-bootstrap';
-import { expect, fireEvent, within } from 'storybook/test';
+import { expect } from 'storybook/test';
 import { Button } from './Button';
 
 const meta = {
@@ -17,14 +16,11 @@ const meta = {
       </ThemeProvider>
     ),
   ],
-  play: async ({ canvasElement }) => {
-    await act(async () => {
-      const canvas = within(canvasElement);
-      await fireEvent.click(canvas.getByText('Button'));
-      // Wait for any updates to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      await expect(canvas.getByText('Button')).toBeVisible();
-    });
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { label: 'Button' }));
+    // Wait for any updates to complete
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(canvas.getByText('Button')).toBeVisible();
   },
   tags: ['autodocs', 'test', 'stable'],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
@@ -130,6 +126,10 @@ export const Disabled = {
   args: {
     label: 'Button',
     disabled: true,
+  },
+  play: async ({ canvas }) => {
+    const button = canvas.getByRole('button', { label: 'Button' });
+    await expect(button).toBeDisabled();
   },
 } satisfies Story;
 

--- a/components/src/button/Button.stories.tsx
+++ b/components/src/button/Button.stories.tsx
@@ -146,27 +146,3 @@ export const Small = {
     label: 'Button',
   },
 } satisfies Story;
-
-// Storybook’s test runner always runs tests in sequence for each story:
-// first the interaction test (play function), then the accessibility test (a11y).
-
-// // It appears that if any tests fail, coverage report is not generated after the run.
-// export const FailingInteractionButton = {
-//   args: {
-//     primary: true,
-//     label: '',
-//   },
-// } satisfies Story;
-//
-export const FailingAccessibilityButton = {
-  args: {
-    label: '',
-  },
-  parameters: {
-    a11y: {
-      // Turning off the check for now so CI can complete.
-      test: 'todo',
-    },
-  },
-  play: async () => {},
-} satisfies Story;


### PR DESCRIPTION
Whats changed?
- Configured a new GHA job to build and publish the StoryBook to Chromatic
- Abstract all the definitions of Node version specification for easier updates
- Remove the act() usage in stories as it is incompatible with Chromatic and not needed for our StoryBook tests anymore
- Removed the example failing accessibility story as it is no longer required
- Removed commented out failing interaction test
- Added a new interaction test for the "Disabled" button story

