### PR TITLE
fix(GHA): Add id-token permission to the StoryBook deploy

### DIFF
--- a/.github/workflows/release-tooling.yml
+++ b/.github/workflows/release-tooling.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       pages: write
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Add missing permission so StoryBook can deploy to GitHub Pages. 