### PR TITLE
chore(ci): Fix up typo on workflow title

### DIFF
--- a/.github/workflows/scorecard-security.yml
+++ b/.github/workflows/scorecard-security.yml
@@ -1,4 +1,4 @@
-name: scorecard security
+name: Scorecard Security
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection


### PR DESCRIPTION
## Description

Fix on a typo on the title of Github Actions Workflow for scorecard security, where others was capitalised

## Related Jira or GitHub Issue

N/A

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

N/A

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant

## Additional Notes

N/A