### PR TITLE
ci(testing): Broaden action to run on main branch updates

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,11 @@
 name: Storybook, Accessibility & Chromatic
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 env:
   NODE_VERSION: 22.13.0


### PR DESCRIPTION
## Description

Configure the testing GHA to run on both pull requests and pushes to the main branch. This was not done previously as it was assumed that it was not required since pull requests already trigged the tests but this may have been incorrect, thus preventing a more optimal use of Chromatic.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-459

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant

