### PR TITLE
ci(publish): Correct the GHA tag reference to run

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,7 +2,7 @@ name: Publish Package
 on:
   push:
     tags:
-      - 'v*'
+      - 'design-system-v*'
 permissions:
   contents: read # Set top-level permissions to read only
 jobs:


### PR DESCRIPTION
## Description

The builds of the MDS are not being shipped across to NPM due to a stale setting of when the publish-package.yml is run.

It was fine until we tweaked how the release-please generates manages tags and this was missed.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-459

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
