### PR TITLE
ci(dependabot): Update groups and linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,27 @@ updates:
     commit-message:
       prefix: ci
     groups:
-      dev-dependencies:
+      minor-and-patch:
         patterns:
           - '*'
-      storybook:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: quarterly
+    commit-message:
+      prefix: ci
+    groups:
+      major:
         patterns:
-          - '@storybook/*'
+          - '*'
+        update-types:
+          - "major"
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -26,5 +26,5 @@ jobs:
           npx commitlint --version
 
       - name: Validate PR commits with commitlint
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         run: npx commitlint -g .github/linters/.commitlintrc.ts --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
## Description

Modified the run groups for Dependabot to only include minor releases & patches in the weekly task to avoid breaking changes coming in sporadically.

Along with this I have made a new runner to run a Major version scan on a quarterly basis to group breaking changes into one pull request so we can tackle them together.

I have also skipped dependabot commits from the commitlint runs till we re-review our linting options.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-429

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
