### PR TITLE
feat(Button): Update example component no longer need React-BS

### DIFF
--- a/components/button/Button.stories.tsx
+++ b/components/button/Button.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ThemeProvider } from 'react-bootstrap';
 import { expect } from 'storybook/test';
 import { Button } from './Button';
 
@@ -16,13 +15,6 @@ const meta = {
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <ThemeProvider>
-        <Story />
-      </ThemeProvider>
-    ),
-  ],
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { label: 'Button' }));
     // Wait for any updates to complete
@@ -74,6 +66,17 @@ const meta = {
           summary: 'true | false',
         },
         defaultValue: { summary: 'false' },
+      },
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['button', 'submit', 'reset'],
+      description: 'Native button type.',
+      table: {
+        type: {
+          summary: 'button | submit | reset',
+        },
+        defaultValue: { summary: 'button' },
       },
     },
   },

--- a/components/button/Button.test.tsx
+++ b/components/button/Button.test.tsx
@@ -27,12 +27,12 @@ describe('Button: Unit Test', () => {
 
   it('applies variant prop', () => {
     render(<Button label="Button" variant="secondary" />);
-    expect(screen.getByRole('button')).toHaveClass('btn-secondary'); // the class applied by react-bootstrap
+    expect(screen.getByRole('button')).toHaveClass('btn-secondary');
   });
 
   it('handles invalid variant prop as default variant', () => {
     render(<Button label="Button" variant="invalid" />);
-    expect(screen.getByRole('button')).toHaveClass('btn-primary'); // the class applied by react-bootstrap
+    expect(screen.getByRole('button')).toHaveClass('btn-primary');
   });
 
   it('applies the size classes', () => {

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -1,16 +1,20 @@
-import {
-  Button as RBButton,
-  ButtonProps as RBButtonProps,
-} from 'react-bootstrap';
+import type { ButtonHTMLAttributes } from 'react';
 
-export interface ButtonProps extends RBButtonProps {
+type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'outline-primary'
+  | 'outline-secondary'
+  | 'outline-danger';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
   variant?: string;
-  disabled?: boolean;
   size?: 'sm' | 'lg';
 }
 
-const allowedVariants = [
+const allowedVariants: ButtonVariant[] = [
   'primary',
   'secondary',
   'danger',
@@ -19,14 +23,30 @@ const allowedVariants = [
   'outline-danger',
 ];
 
-export const Button: React.FC<ButtonProps> = ({ label, variant, ...props }) => {
-  const resolvedVariant = allowedVariants.includes(variant ?? '')
-    ? variant
-    : 'primary';
+export const Button = ({
+  label,
+  variant,
+  size,
+  className,
+  type = 'button',
+  ...props
+}: ButtonProps) => {
+  const resolvedVariant =
+    variant && allowedVariants.includes(variant as ButtonVariant)
+      ? variant
+      : 'primary';
+
+  const classes = ['mds-btn', 'btn', `btn-${resolvedVariant}`];
+  if (size) {
+    classes.push(`btn-${size}`);
+  }
+  if (className) {
+    classes.push(className);
+  }
 
   return (
-    <RBButton className="mds-btn" variant={resolvedVariant} {...props}>
+    <button className={classes.join(' ')} type={type} {...props}>
       {label}
-    </RBButton>
+    </button>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "prettier": "^3.7.3",
         "prettier-plugin-organize-imports": "^4.3.0",
         "react": "^19.2.4",
-        "react-bootstrap": "^2.10.10",
         "react-docgen": "^8.0.2",
         "react-docgen-typescript": "^2.4.0",
         "react-dom": "^19.2.4",
@@ -68,7 +67,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.4",
-        "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.4"
       }
     },
@@ -2523,83 +2521,10 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
-      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@restart/hooks": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
-      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@restart/ui": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
-      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@popperjs/core": "^2.11.8",
-        "@react-aria/ssr": "^3.5.0",
-        "@restart/hooks": "^0.5.0",
-        "@types/warning": "^3.0.3",
-        "dequal": "^2.0.3",
-        "dom-helpers": "^5.2.0",
-        "uncontrollable": "^8.0.4",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
-      }
-    },
-    "node_modules/@restart/ui/node_modules/@restart/hooks": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
-      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@restart/ui/node_modules/uncontrollable": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
-      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.14.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4099,16 +4024,6 @@
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -4322,13 +4237,6 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -4349,27 +4257,10 @@
         "@types/react": "^19.2.0"
       }
     },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.6",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/warning": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5787,13 +5678,6 @@
         }
       }
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -6464,17 +6348,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -8266,16 +8139,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-arguments": {
@@ -10281,27 +10144,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types-extra": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^16.3.2",
-        "warning": "^4.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0"
-      }
-    },
-    "node_modules/prop-types-extra/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -10376,38 +10218,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-bootstrap": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
-      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7",
-        "@restart/hooks": "^0.4.9",
-        "@restart/ui": "^1.9.4",
-        "@types/prop-types": "^15.7.12",
-        "@types/react-transition-group": "^4.4.6",
-        "classnames": "^2.3.2",
-        "dom-helpers": "^5.2.1",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.8.1",
-        "prop-types-extra": "^1.1.0",
-        "react-transition-group": "^4.4.5",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.8",
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-docgen": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.2.tgz",
@@ -10474,13 +10284,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -10489,23 +10292,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/readdirp": {
@@ -12004,22 +11790,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/uncontrollable": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
-      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.6.3",
-        "@types/react": ">=16.9.11",
-        "invariant": "^2.2.4",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0"
-      }
-    },
     "node_modules/undici": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
@@ -12455,16 +12225,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "peerDependencies": {
     "react": "^19.2.4",
-    "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
@@ -74,7 +73,6 @@
     "prettier": "^3.7.3",
     "prettier-plugin-organize-imports": "^4.3.0",
     "react": "^19.2.4",
-    "react-bootstrap": "^2.10.10",
     "react-docgen": "^8.0.2",
     "react-docgen-typescript": "^2.4.0",
     "react-dom": "^19.2.4",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,13 +27,7 @@ export default defineConfig({
     },
     cssCodeSplit: false, // bundle all CSS into a single file
     rollupOptions: {
-      external: [
-        'react',
-        'react-dom',
-        'react-dom/client',
-        'react/jsx-runtime',
-        'react-bootstrap',
-      ],
+      external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime'],
       output: {
         assetFileNames: 'index.css', // name the CSS file
       },


### PR DESCRIPTION
## Description

This PR removes the `react-bootstrap` dependency from the `Button` example component and replaces it with a native `<button>` implementation while preserving existing behavior and Bootstrap-compatible class output.

Key changes:
- Replaced `RBButton` usage with native `<button>` in `components/button/Button.tsx`.
- Switched props base type to `ButtonHTMLAttributes<HTMLButtonElement>`.
- Added explicit variant allowlist and fallback to `primary` for invalid variants.
- Kept size support via `btn-sm` / `btn-lg` classes.
- Preserved class composition with `mds-btn`, `btn`, and variant class.
- Removed `ThemeProvider` decorator from `Button` story (no longer needed).
- Removed `react-bootstrap` from `peerDependencies` and `devDependencies`.
- Removed `react-bootstrap` from Vite externals.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-443

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [x] Refactor
- [ ] Documentation
- [x] Other (dependency removal / package simplification)

## Screenshots/Previews

No visual changes expected beyond removal of `react-bootstrap` runtime dependency.
Storybook `Button` story remains in place and was updated to remove `ThemeProvider`.

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant

## Additional Notes

- Unit tests pass locally with `npm run test-unit` (9/9 passing in `components/button/Button.test.tsx`).
- This change reduces coupling by making the component independent of `react-bootstrap` while keeping bootstrap class conventions.
- `package-lock.json` includes the corresponding dependency graph cleanup.
