### PR TITLE
docs: Add GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,114 @@
+name: Bug report
+description: Report a defect in components, tokens, docs, or build tooling.
+title: 'fix: '
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting an issue in the Moodle Design System.
+        Please include enough detail for us to reproduce and verify a fix.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Pick the area most impacted by this bug.
+      options:
+        - Component
+        - Design token
+        - Documentation
+        - Storybook
+        - Build or tooling
+        - Accessibility
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: component
+    attributes:
+      label: Component or token name
+      description: e.g. Button, Dropdown, token-color-action-primary
+      placeholder: Enter component or token name
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: Which version of @moodlehq/design-system are you using?
+      placeholder: e.g. 0.8.2
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, framework, and rendering mode details.
+      placeholder: e.g. Chrome 123 on macOS 15, React 19, Vite
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include a minimal reproducible example.
+      placeholder: |
+        1. Install package version...
+        2. Render component with props...
+        3. Observe behavior...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: Describe what should happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Describe what happens instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links and evidence
+      description: Storybook URL, screenshots, logs, or failing test output.
+      placeholder: Add links or paste relevant output.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: a11y-impact
+    attributes:
+      label: Accessibility impact
+      description: Does this issue affect WCAG conformance or assistive tech usage?
+      options:
+        - No impact
+        - Unknown
+        - Minor
+        - Major
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I can reproduce this issue with the information provided above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Moodle Design System Matrix channel
+    url: https://matrix.to/#/#moodle.design:moodle.com
+    about: Ask questions or discuss proposals with the design system team.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,94 @@
+name: Feature request
+description: Propose a new component, token, pattern, or platform capability.
+title: 'feat: '
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+        Please describe user value, expected API, and adoption impact.
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Request type
+      options:
+        - New component
+        - Component enhancement
+        - New token
+        - Token update
+        - Documentation improvement
+        - Tooling or developer experience
+        - Accessibility enhancement
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What is hard today, and who is affected?
+      placeholder: Describe the current limitation and context.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe behavior, API shape, and expected usage.
+      placeholder: Include examples of props, tokens, or docs changes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: Describe any workarounds or alternatives.
+    validations:
+      required: false
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Design references
+      description: Add Figma, Zeroheight, screenshots, or related links.
+      placeholder: Paste links here.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: Breaking change risk
+      options:
+        - 'No'
+        - Unsure
+        - 'Yes'
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Suggested priority
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I explained the user impact and expected outcome.
+          required: true


### PR DESCRIPTION
## Description

Enabling Github issue form template for:
- Bugs
- Feature request

The selection for "Report a security vulnerability" are included by GIthub automatically

Also added an entry to matrix channel in case they only have a questions

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-484

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

<img width="828" height="344" alt="Screenshot 2026-03-13 at 10 50 05 am" src="https://github.com/user-attachments/assets/8a46f564-817c-4067-afcd-46ea5cced640" />
<img width="824" height="826" alt="Screenshot 2026-03-13 at 10 50 18 am" src="https://github.com/user-attachments/assets/5de036e3-9296-4a78-b4b7-e0cb510ff398" />
<img width="833" height="848" alt="Screenshot 2026-03-13 at 10 50 24 am" src="https://github.com/user-attachments/assets/ba285219-c207-464e-94ad-4e6617ad4b77" />

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant

## Additional Notes

N/A