### PR TITLE
feat(AI): Add AI agent tooling for streamlined co-working 

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+The GitHub instruction files are the authoritative source for all guidance. Read them before working in this repo:
+
+- **All work:** [.github/copilot-instructions.md](.github/copilot-instructions.md) — setup, commands, commit conventions, architecture, and guardrails
+- **Components (`components/**`):** [.github/instructions/components.instructions.md](.github/instructions/components.instructions.md)
+- **Stories & tests (`*.stories.tsx`, `*.test.tsx`, `tests/**`):** [.github/instructions/stories-tests.instructions.md](.github/instructions/stories-tests.instructions.md)
+- **Token pipeline (`tokens/**`, `scripts/tokens.ts`):** [.github/instructions/tokens.instructions.md](.github/instructions/tokens.instructions.md)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,107 @@
+# GitHub Copilot Instructions
+
+## Project shape (read first)
+
+- This is a React + TypeScript component library built with Vite library mode; public entrypoint is `index.ts` and package exports are defined in `package.json`.
+- Runtime styling flow is: `index.ts` imports Bootstrap base CSS, generated design tokens (`tokens/css/index.css`), then component styles (`components/index.css`). Keep this order.
+- Components apply Bootstrap CSS classes directly in JSX (no `react-bootstrap` dependency). Each component adds a stable `mds-*` class hook and is styled via `--mds-*` CSS custom properties in a colocated CSS file.
+- Token sources are DTCG JSON in `tokens/dtcg/`; generated outputs in `tokens/css/` and `tokens/scss/` are produced by `scripts/tokens.ts` via Style Dictionary.
+
+Published package exports:
+
+| Import | Resolves to |
+|---|---|
+| `@moodlehq/design-system` | `dist/index.js` |
+| `@moodlehq/design-system/css` | `dist/index.css` |
+| `@moodlehq/design-system/tokens/css` | `tokens/css/index.css` |
+| `@moodlehq/design-system/tokens/scss` | `tokens/scss/_index.scss` |
+| `@moodlehq/design-system/tokens/scss/legacy` | `tokens/scss/_index.legacy.scss` |
+
+## Path-specific instruction files
+
+Three scoped files contain the detailed rules for their areas. They auto-load in VS Code/Copilot when a matching file is open. Other agents should read the relevant file proactively before starting work in that area:
+
+- **`components/**`** → `.github/instructions/components.instructions.md`
+- **`*.stories.tsx`, `*.test.tsx`, `tests/**`** → `.github/instructions/stories-tests.instructions.md`
+- **`tokens/**`, `scripts/tokens.ts`** → `.github/instructions/tokens.instructions.md`
+
+## Recommended MCP servers
+
+These MCP servers are useful when working in this repo. Configure them in your AI agent's MCP settings:
+
+| Server | Purpose |
+|---|---|
+| [Figma](https://mcp.figma.com/mcp) (`https://mcp.figma.com/mcp`, HTTP) | Design-to-code work — `get_design_context`, `get_screenshot`, `get_variable_defs`, `get_metadata` |
+| [ZeroHeight](https://mcp.zeroheight.com) (HTTP, requires token — see ZeroHeight docs to generate) | Browsing design system documentation and looking up existing token definitions before requesting new ones |
+| [Storybook](http://localhost:6006/mcp) (`http://localhost:6006/mcp`, HTTP) | Querying rendered stories — served automatically by `@storybook/addon-mcp` when Storybook is running, no separate setup needed |
+| [chrome-devtools-mcp](https://github.com/mlwebdev-js/chrome-devtools-mcp) (`npx -y chrome-devtools-mcp`, stdio) | Inspecting computed styles and debugging rendered output in a browser |
+| [GitHub](https://github.com/github/github-mcp-server) (`npx -y @github/mcp-server`, stdio) | Reading issues and PRs, checking CI status, reviewing pull request comments |
+
+## Setup and development
+
+- Install dependencies: `npm install` then `npx playwright install` (required for Storybook/browser tests).
+- Start Storybook dev server: `npm run storybook` (http://localhost:6006).
+
+## Testing and Storybook workflow
+
+- Unit tests: `npm run test-unit` (Vitest + jsdom, component tests only).
+- Storybook interaction/a11y tests: `npm run test-storybook` (Vitest browser mode + Playwright + Storybook addon plugin).
+- Coverage for unit tests: `npm run test-unit-coverage` (Istanbul thresholds: 50% minimum, 80% target for statement coverage — configured in `vitest.config.ts`).
+- Run a single unit test file: `VITEST_STORYBOOK=false npx vitest run components/button/Button.test.tsx`.
+- The `VITEST_STORYBOOK` env var switches vitest: `false` runs `components/**/*.{test,spec}.*` in jsdom; `true` runs stories tagged `test` via Playwright/Chromium headless.
+- Test configuration lives in `vitest.config.ts`. `vite.config.ts` also defines a Storybook Vitest project (browser + Playwright) as part of the build config — do not edit that block for test configuration changes.
+- Reuse `tests/utils/fuzzComponent.ts` + `fast-check` for property-based fuzz tests where inputs have broad permutations.
+- Story files should include `tags: ['autodocs', 'test', 'stable']` unless intentionally excluding from Storybook Vitest runs.
+
+## Build, lint, and formatting
+
+- Build distributable library with `npm run build` (`tsc && vite build`), output in `dist/`.
+- Build static Storybook: `npm run build-storybook`.
+- Token files are managed by the ZeroHeight PR flow — agents must not run `npm run build-tokens` or edit token sources. Human contributors regenerate with `npm run build-tokens` after `tokens/dtcg/*` changes.
+- Lint with `npm run lint` and format with `npm run format`; both use configs in `.github/linters/`.
+- Keep import ordering compatible with `prettier-plugin-organize-imports` (auto-applied by formatter and lint-staged). Mark type-only imports with `import type`.
+
+## Inline documentation
+
+Add inline comments to explain non-obvious decisions. The bar is: would a competent developer reading this code understand *why* without a comment? If not, add one.
+
+Things that warrant a comment:
+- Runtime validation logic (e.g. why a prop accepts `string` but is validated against a narrower union)
+- CSS specificity choices (e.g. why a double-class selector is used)
+- Workarounds, async timing flushes, or anything that looks wrong but is intentional
+- Type casts (`as unknown as ...`) — explain why the cast is safe
+
+Things that do not need a comment:
+- Self-evident prop assignments, class names, or standard React patterns
+- Anything already explained in the instruction files
+
+## Contributing and release process
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch, PR, review, and release process. Releases are automated via Release Please — do not manually edit the changelog or version.
+
+## Commit conventions
+
+- Commits must follow [Conventional Commits](https://www.conventionalcommits.org/).
+- Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`.
+- Subject must use sentence-case.
+
+## Guardrails
+
+**When adding any CSS value (color, spacing, typography, border, shadow):**
+1. Check `tokens/css/` or use Figma MCP (`get_variable_defs` / `get_design_context`) to find an existing `--mds-*` token.
+2. If a matching token exists → use it via `var(--mds-*)`.
+3. If no token exists → do not invent an ad-hoc value. Ask contributors to request one at https://design.moodle.com/.
+
+**When working from a Figma design:**
+1. Fetch `get_design_context` (structure) and `get_screenshot` (visual reference) before writing any code.
+2. If the context payload is too large, use `get_metadata` to narrow scope and re-fetch the target node.
+3. Treat Figma MCP output as a design reference — translate it to existing component patterns and `--mds-*` token CSS, not final code.
+4. Use any SVG/image assets Figma MCP provides directly; do not add new icon or image packages.
+5. Figma team files: https://www.figma.com/files/1539002666003113376/team/1542064100377724261/Moodle-Design-System
+
+**When making any change:**
+- Do not edit or regenerate token files. `tokens/dtcg/**/*.json`, `tokens/css/**`, and `tokens/scss/**` are managed by the ZeroHeight PR flow — agents must not edit them directly or run `npm run build-tokens`.
+- Prefer extending existing component patterns; avoid new architectural layers, context providers, or state abstractions.
+- Do not add new npm dependencies unless the task explicitly requires an external package and no existing utility covers the need. Do not add icon or image packages — use assets provided by Figma MCP instead.
+- Preserve the Storybook a11y setup and theme decorator in `.storybook/preview.ts`.
+- Do not touch release automation, workflow files (`.github/workflows/`), `CHANGELOG.md`, or `package.json` version fields unless the task explicitly requires it.

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -1,0 +1,134 @@
+---
+applyTo: 'components/**/*.{ts,tsx,css}'
+---
+
+# Components Instructions
+
+## File structure
+
+Each component lives in its own folder and must contain all five files:
+
+```
+components/<name>/
+  ComponentName.tsx         # implementation
+  component-name.css        # component-scoped styles using --mds-* tokens
+  ComponentName.test.tsx    # Vitest unit tests
+  ComponentName.stories.tsx # Storybook stories (also used for interaction/a11y tests)
+  index.tsx                 # local barrel: export * from './ComponentName';
+```
+
+Add named and type exports to `components/index.tsx`:
+
+```ts
+export { Button } from './button';
+export type { ButtonProps } from './button';
+```
+
+Consumers import from the package root only — subpath imports per component are not supported.
+
+## Breaking change guardrail
+
+The following changes to a component's public API are breaking and must not be made without a major version bump:
+
+| Change | Why it breaks |
+|---|---|
+| Removing or renaming a prop | Existing callers pass the old name and get no value |
+| Narrowing a prop's type (e.g. `string` → `'a' \| 'b'`) | Valid values callers already pass become type errors |
+| Changing a prop's runtime behavior or default | Callers relying on the old default get a different result silently |
+| Removing or renaming an export | Import statements in consumer code stop resolving |
+| Changing the root element type (e.g. `<button>` → `<div>`) | Breaks CSS selectors, ARIA roles, and event forwarding in consumer apps |
+
+Safe (non-breaking) changes: adding an optional prop with a default, widening a type, adding a new export, adding a value to `allowedVariants`.
+
+Note: removing or renaming a value in the `allowedVariants` array is also breaking — consumers passing that value will silently fall back to the default variant instead of getting an error.
+
+## Props interface
+
+Extend React native HTML element interfaces, not third-party library types:
+
+```ts
+import type { ButtonHTMLAttributes } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  variant?: string; // intentionally broad — see runtime validation below
+  size?: 'sm' | 'lg';
+}
+```
+
+Use `interface`, not `type`, for props. Use `import type` for type-only imports.
+
+## Runtime validation for constrained props
+
+Props with a fixed set of allowed values must use runtime validation with an `allowedValues` array — TypeScript types alone are not enough, because external consumers can pass any string. Accept the prop as a broad type (`string`) in the interface and resolve to a safe default if an invalid value arrives:
+
+```ts
+type ButtonVariant = 'primary' | 'secondary' | 'danger';
+const allowedVariants: ButtonVariant[] = ['primary', 'secondary', 'danger'];
+
+// In the component body:
+const resolvedVariant =
+  variant && allowedVariants.includes(variant as ButtonVariant)
+    ? variant
+    : 'primary'; // fallback to default
+```
+
+## Class composition
+
+Build `className` as an array and join with a space. Always include the `mds-*` hook first, then any consumer-provided `className` last.
+
+For components built on a Bootstrap base class (e.g. `btn`): include the Bootstrap base class after `mds-*`, then Bootstrap modifier classes (e.g. `btn-primary`). Both the `mds-*` and Bootstrap classes are required in this case — Bootstrap provides the base styles, `mds-*` is the hook for MDS token overrides.
+
+For components not built on Bootstrap: the `mds-*` hook is still required; omit Bootstrap classes entirely.
+
+```tsx
+// Example: component with Bootstrap base
+const classes = ['mds-btn', 'btn', `btn-${resolvedVariant}`];
+if (size) classes.push(`btn-${size}`);
+if (className) classes.push(className);
+
+return <button className={classes.join(' ')} type={type} {...props}>{label}</button>;
+```
+
+Spread `...props` last so consumers can pass `aria-*`, `data-*`, event handlers, and other native attributes through without explicit forwarding.
+
+## Agent guardrails
+
+**Do not remove or rename exports from `components/index.tsx`.** Every named export is part of the public API — removing one is a breaking change with no compile-time error in the library build (story/test files are excluded from `tsconfig.json`). Only add exports; never remove or rename without an explicit breaking-change task.
+
+**Do not add icon, image, or asset packages.** Use SVG/image assets provided directly by Figma MCP (`get_design_context`, `get_screenshot`). Adding new packages for icons or images is not permitted.
+
+## CSS styling
+
+Colocate styles in `component-name.css` (lowercase kebab-case filename, e.g. `button.css` not `Button.css`). Use `--mds-*` CSS custom properties exclusively — no hardcoded colors, spacing, or typography values.
+
+Component styles layer on top of Bootstrap CSS classes. The JSX applies both the Bootstrap base class (e.g. `.btn`) and the `mds-*` hook, so CSS rules target both together to control specificity:
+
+**Three selector levels are used — pick the right one for the job:**
+
+```css
+/* 1. Base: .mds-btn.btn (double-class, specificity 0,2,0)
+      Overrides Bootstrap's single-class .btn rules */
+.mds-btn.btn {
+  background-color: var(--mds-bg-interactive-primary-default);
+  border-radius: var(--mds-border-radius-lg);
+  padding: var(--mds-spacing-xs) var(--mds-spacing-sm);
+  font-size: var(--mds-font-size-paragraph-default);
+}
+
+/* 2. Variant: .mds-btn.btn-{variant} (double-class, same specificity as base)
+      Wins over the base rule by cascade order — placed after it in the file */
+.mds-btn.btn-danger {
+  background-color: var(--mds-bg-interactive-danger-default);
+}
+
+/* 3. State on variant: .mds-btn.btn.btn-{variant}:pseudo (triple-class, specificity 0,3,0)
+      Needed when the state rule must beat both the base and the variant rule */
+.mds-btn.btn.btn-danger:disabled {
+  background-color: var(--mds-bg-interactive-danger-disabled);
+}
+```
+
+Never use `!important` — always resolve conflicts through specificity or cascade order.
+
+Token naming follows `--mds-{category}-{subcategory}-{modifier}` — for example `--mds-bg-interactive-primary-default`, `--mds-spacing-xs`, `--mds-font-size-paragraph-default`. See `tokens/css/` for the full set.

--- a/.github/instructions/stories-tests.instructions.md
+++ b/.github/instructions/stories-tests.instructions.md
@@ -1,0 +1,83 @@
+---
+applyTo: 'components/**/*.{stories,test}.tsx,tests/**/*.ts'
+---
+
+# Stories and Tests Instructions
+
+## Story files (CSF format)
+
+### Meta object and story definitions
+
+Follow the existing pattern in `components/button/Button.stories.tsx` — it shows the canonical structure for the `meta` object (title, component, parameters, tags, argTypes, args, play) and individual story exports. Reuse that format directly; adjust for the target component's props.
+
+### play functions
+
+Two things differ from standard Vitest/Testing Library — get these wrong and tests will fail silently or not run at all:
+
+- **Use `canvas`, not `screen`** — `canvas` is scoped to the story's rendered DOM. `screen` is global and will pick up the wrong element.
+- **Import `expect` from `'storybook/test'`**, not from `'vitest'` — they look identical but only the Storybook one works inside a `play` function.
+
+Everything else:
+- `userEvent` provides interactions: `userEvent.click()`, `userEvent.type()`, `userEvent.hover()`, etc.
+- Always `await` interactions and assertions.
+- Use `await new Promise(r => setTimeout(r, 0))` to flush the microtask queue if assertions fail spuriously after an interaction.
+- A `play` at meta level runs for **all** stories; a `play` on a specific story overrides it for that story only.
+
+### Tags
+
+| Tag | Effect |
+|---|---|
+| `autodocs` | Generates an API documentation page for the component |
+| `test` | Includes the story in `npm run test-storybook` (Playwright/Chromium) |
+| `stable` | Informational — marks the story as production-ready |
+| `experimental` | Excludes the story from Storybook Vitest test runs |
+
+Default for new stories: `tags: ['autodocs', 'test', 'stable']`.
+
+### a11y
+
+Every story tagged `test` is automatically scanned by Axe against WCAG 2.x AA and best-practice rules (configured in `.storybook/preview.ts`). Violations are reported as errors. Do not disable a11y checks without a documented reason.
+
+## Unit tests (Vitest + jsdom)
+
+Run with `npm run test-unit`. Tests live in `ComponentName.test.tsx` alongside the component.
+
+### What to cover
+
+At minimum, cover the following for each component:
+
+- `mds-*` class applied to root element
+- Correct classes applied for each variant and size
+- Invalid variant prop falls back to the default
+- Extra props forwarded to the underlying element (`data-testid`, `aria-label`, etc.)
+- Disabled state behaves correctly
+- Label/content renders as expected
+
+These are a baseline — add additional cases for edge cases and interactions specific to the component. See `components/button/Button.test.tsx` for an example of the test file structure and assertion patterns.
+
+### Property-based fuzzing
+
+Use fuzzing only when a component has a large combinatorial prop space where exhaustive manual cases would be impractical (e.g. 3+ independent props each with multiple values). For simple components with a small number of variants, standard `it` tests are sufficient and preferred.
+
+Use `fuzzComponent` from `tests/utils/fuzzComponent.ts` with `fast-check` when a component has many prop combinations. It renders the component with randomly generated props and asserts the key text is visible.
+
+See `components/button/Button.test.tsx` for a concrete fuzz test using `fuzzComponent` and `fast-check`. Follow that pattern — pass `fc.record` of the component's props and a `getText` function that returns the text to assert is visible. The `as unknown as fc.Arbitrary<...>` casts are expected throughout (fast-check's inferred types don't always satisfy prop types exactly; the cast is safe when the generated values match the prop contract).
+
+## Agent guardrails
+
+**Do not skip or disable tests.** Never use `it.skip`, `test.skip`, `describe.skip`, or remove a `play` function to make a test pass. If a test is failing, fix the underlying issue. If skipping is genuinely necessary (e.g. a known upstream bug), add an inline comment with the reason and a ticket reference.
+
+**In story files, always import `expect` from `'storybook/test'`, never from `'vitest'`.** This is a hard rule — using the Vitest import inside a `play` function will cause tests to fail silently or not run at all.
+
+## TypeScript and the build
+
+Story and test files (`*.stories.tsx`, `*.test.tsx`) are excluded from `tsconfig.json` and the Vite library build — they are not part of the published package. Type errors in these files will not surface in `npm run build`. Run `npm run test-unit` or `npm run test-storybook` to catch type errors in test code.
+
+## Test environment differences
+
+| Mode | Command | Runner | DOM | Includes |
+|---|---|---|---|---|
+| Unit | `npm run test-unit` | Vitest | jsdom | `components/**/*.{test,spec}.tsx` |
+| Storybook | `npm run test-storybook` | Vitest + Playwright | Chromium | Stories tagged `test` |
+
+Use unit tests for behavior contracts (class application, prop validation, prop forwarding). Use story `play` functions for user interactions and visual/a11y state.

--- a/.github/instructions/tokens.instructions.md
+++ b/.github/instructions/tokens.instructions.md
@@ -1,0 +1,81 @@
+---
+applyTo: 'tokens/dtcg/**/*.json,scripts/tokens.ts,tokens/css/**,tokens/scss/**'
+---
+
+# Tokens Instructions
+
+## Agent guardrail — do not modify token files
+
+**Agents must not edit any token files.** `tokens/dtcg/**/*.json`, `tokens/css/**`, and `tokens/scss/**` are all managed externally:
+
+- `tokens/dtcg/*.json` — governed by an automated ZeroHeight PR flow. Changes must go through that process, not be made locally by an agent.
+- `tokens/css/*` and `tokens/scss/*` — generated outputs rebuilt from DTCG sources. Never edit directly.
+
+If a token change is needed, direct the contributor to request it via https://design.moodle.com/.
+
+## Token sources
+
+`tokens/dtcg/*.json` are the governed sources in [DTCG format](https://www.designtokens.org/). They are managed by an automated ZeroHeight PR flow — align token changes with that process rather than editing locally.
+
+## Regenerating tokens
+
+> **Agents: do not follow these steps.** Token changes must go through the ZeroHeight PR flow. This section is for human contributors only.
+
+After any change to `tokens/dtcg/*.json`, run:
+
+```bash
+npm run build-tokens
+```
+
+Then commit **both** the source changes and the regenerated outputs in `tokens/css/` and `tokens/scss/` together in the same commit.
+
+This invokes `scripts/tokens.ts` via Style Dictionary and produces:
+
+- `tokens/css/` — CSS custom properties prefixed `--mds-`, plus `index.css` that imports them all
+- `tokens/scss/` — SCSS variables prefixed `$mds-` with `!default`, plus `_index.scss` (`@forward`) and `_index.legacy.scss` (`@import` for `scssphp` — tag: `MDS_LEGACY_SCSSPHP_COMPAT`)
+
+A custom transform (`dimension-px-to-rem`) converts `$type: "number"` dimension tokens from px to rem (÷16), excluding font-weight tokens.
+
+## Token naming convention
+
+Tokens follow a hierarchical naming pattern: `--mds-{category}-{subcategory}-{modifier}`
+
+| Category | Examples |
+|---|---|
+| Background | `--mds-bg-interactive-primary-default`, `--mds-bg-interactive-primary-hover`, `--mds-bg-interactive-primary-disabled` |
+| Text | `--mds-text-default`, `--mds-text-inverse`, `--mds-text-muted`, `--mds-text-danger` |
+| Border | `--mds-border-translucent`, `--mds-border-interactive-primary-default`, `--mds-border-radius-lg` |
+| Spacing | `--mds-spacing-xxs`, `--mds-spacing-xs`, `--mds-spacing-sm`, `--mds-spacing-md` |
+| Typography | `--mds-font-family-base`, `--mds-font-weight-regular`, `--mds-font-size-paragraph-default`, `--mds-line-height-paragraph-small`, `--mds-letter-spacing-default` |
+| Stroke | `--mds-stroke-weight-sm` |
+| Shadow | `--mds-shadow-lg` |
+
+State variants follow the pattern `...-default`, `...-hover`, `...-active`, `...-disabled`.
+
+## Discovering available tokens
+
+Browse the generated files in `tokens/css/` (e.g. `colors.css`, `spacing.css`, `typography.css`) or use the Figma MCP token definitions via `get_design_context` or `get_variable_defs` against the Moodle Design System Figma team files.
+
+## Using tokens in component CSS
+
+Use CSS custom properties via `var()`. Never hardcode color, spacing, typography, border, or shadow values. Do not add fallback values to `var()` calls — tokens are always defined via the `index.ts` import chain, so a fallback would only mask a missing token that should be fixed at the source.
+
+See `components/button/button.css` for a concrete example of correct token usage in component styles.
+
+## Breaking change guardrail
+
+Renaming or removing a token is a breaking change — consumer code referencing the old name will silently lose its value (the `var()` resolves to nothing with no error).
+
+The following changes must not be made without a major version bump:
+
+| Change | Why it breaks |
+|---|---|
+| Renaming a token | Any `var(--mds-old-name)` in consumer CSS stops resolving |
+| Removing a token | Same as above |
+| Changing a token's type or unit (e.g. `px` → `rem` at the source level) | Changes computed values in consumer layouts |
+
+Safe (non-breaking) changes: adding a new token, changing a token's value within the same type and unit.
+
+## If no token exists
+
+Do not invent an ad-hoc CSS variable or hardcode a raw value. Ask contributors to request a token via https://design.moodle.com/.


### PR DESCRIPTION
## Description

This PR adds comprehensive AI agent tooling to the repository, giving tools like Claude Code, GitHub Copilot, and other AI assistants the context they need to contribute safely and consistently to the design system.

Two changes are included:

**1. AI instruction files for GitHub Copilot / AI agents**

A root-level `copilot-instructions.md` covers repo shape, setup commands, commit conventions, testing workflow, and guardrails. Three path-scoped instruction files auto-load in VS Code when a matching file is open:

- `.github/instructions/components.instructions.md` — component authoring patterns, CSS conventions, prop types, and the component Definition of Done
- `.github/instructions/stories-tests.instructions.md` — story structure, interaction test patterns, a11y testing, and fuzz testing with `fast-check`
- `.github/instructions/tokens.instructions.md` — token pipeline rules and the ZeroHeight-managed read-only constraint on token sources

Key guardrails baked into the instructions prevent AI agents from editing token source files, adding unsanctioned npm dependencies, inventing ad-hoc CSS values instead of `--mds-*` tokens, or touching release automation and workflow files.

**2. Claude Code instructions (`.claude/CLAUDE.md`)**

Added a `.claude/CLAUDE.md` entry point that points Claude Code to the GitHub instruction files as the authoritative source of guidance, avoiding duplication.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-408

## Type of Change

- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

No UI changes. No Storybook story changes.

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate) — N/A, no component changes
- [x] I have considered accessibility and described any improvements or issues — N/A, no UI changes
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant — instruction files explicitly guard against agents touching release automation, token sources, or workflow files

## Additional Notes

N/A
