### PR TITLE
fix(AI): Add i18n guidance to instructions

### DIFF
--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -92,6 +92,36 @@ return <button className={classes.join(' ')} type={type} {...props}>{label}</but
 
 Spread `...props` last so consumers can pass `aria-*`, `data-*`, event handlers, and other native attributes through without explicit forwarding.
 
+## Internationalisation
+
+Moodle is available in 100+ languages and supports RTL scripts (Arabic, Hebrew, Farsi, etc.). All components must be i18n-ready without coupling to any i18n library.
+
+**Strings:** Never hardcode user-facing text inside a component. Every visible string — labels, accessible names, placeholders, tooltips — must be accepted as a prop. The caller is responsible for translation.
+
+```tsx
+// ✅ correct
+<Button label={t('core:save')} />
+
+// ❌ wrong
+return <button>Save</button>;
+```
+
+**CSS logical properties:** Use logical properties instead of physical directional ones so layout mirrors correctly under RTL without extra CSS.
+
+| Avoid | Use instead |
+|---|---|
+| `margin-left` / `margin-right` | `margin-inline-start` / `margin-inline-end` |
+| `padding-left` / `padding-right` | `padding-inline-start` / `padding-inline-end` |
+| `left` / `right` (positioning) | `inset-inline-start` / `inset-inline-end` |
+| `border-left` / `border-right` | `border-inline-start` / `border-inline-end` |
+| `text-align: left` / `text-align: right` | `text-align: start` / `text-align: end` |
+
+Direction-neutral properties (`top`, `bottom`, `height`, `width`, `margin-top`, `padding-top`, etc.) do not need changing.
+
+**`dir` attribute:** No explicit forwarding needed — writing direction is inherited from the document or nearest ancestor. Because `...props` is always spread on the root element, consumers can pass `dir` directly if needed.
+
+**Locale-aware formatting:** This library is presentation-only and does not format dates, numbers, or currency. Components accept pre-formatted strings; locale-aware formatting is the consumer's responsibility.
+
 ## Agent guardrails
 
 **Do not remove or rename exports from `components/index.tsx`.** Every named export is part of the public API — removing one is a breaking change with no compile-time error in the library build (story/test files are excluded from `tsconfig.json`). Only add exports; never remove or rename without an explicit breaking-change task.

--- a/.github/instructions/stories-tests.instructions.md
+++ b/.github/instructions/stories-tests.instructions.md
@@ -38,6 +38,24 @@ Default for new stories: `tags: ['autodocs', 'test', 'stable']`.
 
 Every story tagged `test` is automatically scanned by Axe against WCAG 2.x AA and best-practice rules (configured in `.storybook/preview.ts`). Violations are reported as errors. Do not disable a11y checks without a documented reason.
 
+### RTL
+
+For any component that has directional layout (padding, margin, alignment, positioning, icons with a side), add an RTL story that wraps the component in a `dir="rtl"` container. This verifies that CSS logical properties are in use and the layout mirrors correctly.
+
+```tsx
+export const RightToLeft: Story = {
+  decorators: [
+    (Story) => (
+      <div dir="rtl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+```
+
+Tag RTL stories with `['test', 'stable']` (omit `autodocs` — they are structural tests, not API documentation).
+
 ## Unit tests (Vitest + jsdom)
 
 Run with `npm run test-unit`. Tests live in `ComponentName.test.tsx` alongside the component.


### PR DESCRIPTION
## Description

Adds an **Internationalisation** section to the component authoring instructions and an **RTL** section to the stories & tests instructions. These changes bring the AI coding guidance into alignment with item 25 of the [end-to-end component checklist](https://moodle.atlassian.net/wiki/spaces/MDS/pages/3767074817/End-to-end+component+checklist).

The new guidance covers:
- All user-facing strings must be accepted as props — no hardcoded text inside component markup
- CSS logical properties must be used in place of physical directional properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`, `text-align: start/end`)
- `dir` attribute passthrough is already covered by the existing `...props` spread convention
- A canonical `RightToLeft` Storybook story must be added for any component with asymmetric or directional layout
- Components must not format locale-sensitive data — they accept pre-formatted strings only

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-524

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

No UI changes.

## Checklist

- [ ] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate) — the RTL story template is documented in the stories & tests instructions
- [x] I have considered accessibility and described any improvements or issues — RTL support is an accessibility and internationalisation concern; the guidance ensures layout correctness for RTL scripts (Arabic, Hebrew, Farsi)
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant — no security implications

## Additional Notes

These are instruction files consumed by AI coding agents (Claude Code, Copilot, etc.) and human contributors. The changes do not modify any component source, CSS, or test files. The intent is to ensure that the next component built — by a human or an AI agent — is i18n-ready by default, without requiring a separate audit pass.
