### PR TITLE
ci: Operationalise component build checklist and tighten linting

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,6 +5,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 The GitHub instruction files are the authoritative source for all guidance. Read them before working in this repo:
 
 - **All work:** [.github/copilot-instructions.md](.github/copilot-instructions.md) — setup, commands, commit conventions, architecture, and guardrails
-- **Components (`components/**`):** [.github/instructions/components.instructions.md](.github/instructions/components.instructions.md)
-- **Stories & tests (`*.stories.tsx`, `*.test.tsx`, `tests/**`):** [.github/instructions/stories-tests.instructions.md](.github/instructions/stories-tests.instructions.md)
-- **Token pipeline (`tokens/**`, `scripts/tokens.ts`):** [.github/instructions/tokens.instructions.md](.github/instructions/tokens.instructions.md)
+- **Components (`components/**`):\*\* [.github/instructions/components.instructions.md](.github/instructions/components.instructions.md)
+- **Stories & tests (`*.stories.tsx`, `*.test.tsx`, `tests/**`):\*\* [.github/instructions/stories-tests.instructions.md](.github/instructions/stories-tests.instructions.md)
+- **Token pipeline (`tokens/**`, `scripts/tokens.ts`):\*\* [.github/instructions/tokens.instructions.md](.github/instructions/tokens.instructions.md)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,12 +85,12 @@ To set up a local development environment:
 
 When building or significantly changing a component, checklist items are enforced at four levels:
 
-| Level | What it means | Examples |
-| --- | --- | --- |
-| **CI-enforced** | Automated — PR cannot merge if it fails | Unit tests + coverage, Storybook interaction + Axe a11y, Chromatic (design sign-off), CodeQL, commitlint, ESLint, Prettier, build |
-| **Author self-check** | PR template checkbox — author attests before requesting review | File structure, i18n (logical CSS properties, no hardcoded strings), CSS token usage (`var(--mds-*)`), breaking change assessment, instruction file updates |
-| **Reviewer-verified** | Reviewer actively checks during code review | Props interface quality (JSDoc, `allowedValues`, `...props` spread), test coverage completeness, RTL story present where needed |
-| **Role-specific sign-off** | Requires a specific person to approve | Cross-system parity check across code, Storybook, Figma, and Zeroheight |
+| Level                      | What it means                                                  | Examples                                                                                                                                                    |
+| -------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CI-enforced**            | Automated — PR cannot merge if it fails                        | Unit tests + coverage, Storybook interaction + Axe a11y, Chromatic (design sign-off), CodeQL, commitlint, ESLint, Prettier, build                           |
+| **Author self-check**      | PR template checkbox — author attests before requesting review | File structure, i18n (logical CSS properties, no hardcoded strings), CSS token usage (`var(--mds-*)`), breaking change assessment, instruction file updates |
+| **Reviewer-verified**      | Reviewer actively checks during code review                    | Props interface quality (JSDoc, `allowedValues`, `...props` spread), test coverage completeness, RTL story present where needed                             |
+| **Role-specific sign-off** | Requires a specific person to approve                          | Cross-system parity check across code, Storybook, Figma, and Zeroheight                                                                                     |
 
 The full end-to-end component checklist is maintained internally by the Moodle HQ Design System team.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,10 +10,11 @@ Thank you for your interest in contributing to the Moodle Design System! This pr
 - [How to Contribute](#how-to-contribute)
 - [Code Style, Linting & Commit Messages](#code-style-linting--commit-messages)
 - [Submitting Changes](#submitting-changes)
+- [Component checklist enforcement](#component-checklist-enforcement)
 - [Documentation Contributions](#documentation-contributions)
 - [Review Process](#review-process)
 - [Release Process](#release-process)
-- [Code of Conduct](#code-of-conduct)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Getting Help](#getting-help)
 
 ## Getting Started
@@ -31,16 +32,21 @@ Please read our [Contributors Guide](https://moodledev.io/general/documentation/
 To set up a local development environment:
 
 1. **Clone the repository:**
+
    ```sh
    git clone https://github.com/moodlehq/design-system.git
    cd design-system
    ```
+
 2. **Install dependencies:**
+
    ```sh
    npm install
    npx playwright install
    ```
+
 3. **Run Storybook (development server):**
+
    ```sh
    npm run storybook
    ```
@@ -71,7 +77,22 @@ To set up a local development environment:
    - `npm run test-unit` (unit tests)
    - `npm run test-unit-coverage` (unit test coverage)
 3. Open a pull request with a clear description of your changes.
+   - For new or significantly changed components, use the [component PR template](https://github.com/moodlehq/design-system/compare/main...your-branch?template=component.md) by appending `?template=component.md` to the PR URL.
+   - For all other changes (bugfixes, refactors, docs), the default template is used automatically.
 4. Participate in the code review process and make any requested changes.
+
+## Component checklist enforcement
+
+When building or significantly changing a component, checklist items are enforced at four levels:
+
+| Level | What it means | Examples |
+| --- | --- | --- |
+| **CI-enforced** | Automated — PR cannot merge if it fails | Unit tests + coverage, Storybook interaction + Axe a11y, Chromatic (design sign-off), CodeQL, commitlint, ESLint, Prettier, build |
+| **Author self-check** | PR template checkbox — author attests before requesting review | File structure, i18n (logical CSS properties, no hardcoded strings), CSS token usage (`var(--mds-*)`), breaking change assessment, instruction file updates |
+| **Reviewer-verified** | Reviewer actively checks during code review | Props interface quality (JSDoc, `allowedValues`, `...props` spread), test coverage completeness, RTL story present where needed |
+| **Role-specific sign-off** | Requires a specific person to approve | Cross-system parity check across code, Storybook, Figma, and Zeroheight |
+
+The full end-to-end component checklist is maintained internally by the Moodle HQ Design System team.
 
 ## Documentation Contributions
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,8 @@
 - [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
 - [ ] I have considered accessibility and described any improvements or issues
 - [ ] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
+- [ ] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
+- [ ] Instruction files updated if this change introduces new patterns or anti-patterns
 
 ## Additional Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE/component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/component.md
@@ -1,0 +1,58 @@
+## Description
+
+<!-- Describe the component, what it does, and the motivation for building or changing it -->
+
+## Related Jira or GitHub Issue
+
+<!-- Link to the related issue or ticket (e.g., https://moodle.atlassian.net/browse/MDS-191) -->
+
+## Screenshots/Previews
+
+<!-- Reference Chromatic visual diffs, add screenshots, or link to Storybook previews -->
+
+## Author checklist
+
+### File structure and exports
+
+- [ ] All 5 required files present: `ComponentName.tsx`, `component-name.css`, `ComponentName.test.tsx`, `ComponentName.stories.tsx`, `index.tsx`
+- [ ] Named and type exports added to `components/index.tsx`
+- [ ] Component stylesheet imported in `components/index.css`
+
+### TypeScript and props
+
+- [ ] Props interface extends the correct React HTML element interface (e.g. `ButtonHTMLAttributes<HTMLButtonElement>`)
+- [ ] JSDoc comment on each prop
+- [ ] Constrained props use `allowedValues` runtime validation with a graceful fallback to a documented default
+- [ ] `...props` spread last on the root element
+
+### Internationalisation
+
+- [ ] All user-facing strings accepted as props — no hardcoded text in JSX
+- [ ] CSS uses logical properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`) for any directional layout
+- [ ] RTL story added if the component has directional layout
+
+### CSS and tokens
+
+- [ ] All CSS values use `var(--mds-*)` tokens — no hardcoded colours, spacing, or typography
+
+### Tests and stories
+
+- [ ] Unit tests cover: `mds-*` class on root, correct classes per variant/size, invalid prop fallback, prop forwarding, disabled state, and label rendering
+- [ ] Storybook stories cover all documented variants, sizes, and states
+- [ ] Accessibility tested — Axe WCAG AA scan runs automatically via CI on all stories tagged `test`
+
+### Breaking changes
+
+- [ ] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
+
+### AI context
+
+- [ ] Instruction files updated if this component introduces new patterns or anti-patterns
+
+## Cross-system parity
+
+- [ ] Component name, prop names, and variant names are consistent across code, Storybook, Figma, and Zeroheight
+
+## Additional Notes
+
+<!-- Add any other context or information reviewers should know -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,12 +9,12 @@
 
 Published package exports:
 
-| Import | Resolves to |
-|---|---|
-| `@moodlehq/design-system` | `dist/index.js` |
-| `@moodlehq/design-system/css` | `dist/index.css` |
-| `@moodlehq/design-system/tokens/css` | `tokens/css/index.css` |
-| `@moodlehq/design-system/tokens/scss` | `tokens/scss/_index.scss` |
+| Import                                       | Resolves to                      |
+| -------------------------------------------- | -------------------------------- |
+| `@moodlehq/design-system`                    | `dist/index.js`                  |
+| `@moodlehq/design-system/css`                | `dist/index.css`                 |
+| `@moodlehq/design-system/tokens/css`         | `tokens/css/index.css`           |
+| `@moodlehq/design-system/tokens/scss`        | `tokens/scss/_index.scss`        |
 | `@moodlehq/design-system/tokens/scss/legacy` | `tokens/scss/_index.legacy.scss` |
 
 ## Path-specific instruction files
@@ -29,13 +29,13 @@ Three scoped files contain the detailed rules for their areas. They auto-load in
 
 These MCP servers are useful when working in this repo. Configure them in your AI agent's MCP settings:
 
-| Server | Purpose |
-|---|---|
-| [Figma](https://mcp.figma.com/mcp) (`https://mcp.figma.com/mcp`, HTTP) | Design-to-code work — `get_design_context`, `get_screenshot`, `get_variable_defs`, `get_metadata` |
-| [ZeroHeight](https://mcp.zeroheight.com) (HTTP, requires token — see ZeroHeight docs to generate) | Browsing design system documentation and looking up existing token definitions before requesting new ones |
-| [Storybook](http://localhost:6006/mcp) (`http://localhost:6006/mcp`, HTTP) | Querying rendered stories — served automatically by `@storybook/addon-mcp` when Storybook is running, no separate setup needed |
-| [chrome-devtools-mcp](https://github.com/mlwebdev-js/chrome-devtools-mcp) (`npx -y chrome-devtools-mcp`, stdio) | Inspecting computed styles and debugging rendered output in a browser |
-| [GitHub](https://github.com/github/github-mcp-server) (`npx -y @github/mcp-server`, stdio) | Reading issues and PRs, checking CI status, reviewing pull request comments |
+| Server                                                                                                          | Purpose                                                                                                                        |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [Figma](https://mcp.figma.com/mcp) (`https://mcp.figma.com/mcp`, HTTP)                                          | Design-to-code work — `get_design_context`, `get_screenshot`, `get_variable_defs`, `get_metadata`                              |
+| [ZeroHeight](https://mcp.zeroheight.com) (HTTP, requires token — see ZeroHeight docs to generate)               | Browsing design system documentation and looking up existing token definitions before requesting new ones                      |
+| [Storybook](http://localhost:6006/mcp) (`http://localhost:6006/mcp`, HTTP)                                      | Querying rendered stories — served automatically by `@storybook/addon-mcp` when Storybook is running, no separate setup needed |
+| [chrome-devtools-mcp](https://github.com/mlwebdev-js/chrome-devtools-mcp) (`npx -y chrome-devtools-mcp`, stdio) | Inspecting computed styles and debugging rendered output in a browser                                                          |
+| [GitHub](https://github.com/github/github-mcp-server) (`npx -y @github/mcp-server`, stdio)                      | Reading issues and PRs, checking CI status, reviewing pull request comments                                                    |
 
 ## Setup and development
 
@@ -63,15 +63,17 @@ These MCP servers are useful when working in this repo. Configure them in your A
 
 ## Inline documentation
 
-Add inline comments to explain non-obvious decisions. The bar is: would a competent developer reading this code understand *why* without a comment? If not, add one.
+Add inline comments to explain non-obvious decisions. The bar is: would a competent developer reading this code understand _why_ without a comment? If not, add one.
 
 Things that warrant a comment:
+
 - Runtime validation logic (e.g. why a prop accepts `string` but is validated against a narrower union)
 - CSS specificity choices (e.g. why a double-class selector is used)
 - Workarounds, async timing flushes, or anything that looks wrong but is intentional
 - Type casts (`as unknown as ...`) — explain why the cast is safe
 
 Things that do not need a comment:
+
 - Self-evident prop assignments, class names, or standard React patterns
 - Anything already explained in the instruction files
 
@@ -88,11 +90,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for branch, PR, review, and release proce
 ## Guardrails
 
 **When adding any CSS value (color, spacing, typography, border, shadow):**
+
 1. Check `tokens/css/` or use Figma MCP (`get_variable_defs` / `get_design_context`) to find an existing `--mds-*` token.
 2. If a matching token exists → use it via `var(--mds-*)`.
 3. If no token exists → do not invent an ad-hoc value. Ask contributors to request one at https://design.moodle.com/.
 
 **When working from a Figma design:**
+
 1. Fetch `get_design_context` (structure) and `get_screenshot` (visual reference) before writing any code.
 2. If the context payload is too large, use `get_metadata` to narrow scope and re-fetch the target node.
 3. Treat Figma MCP output as a design reference — translate it to existing component patterns and `--mds-*` token CSS, not final code.
@@ -100,6 +104,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for branch, PR, review, and release proce
 5. Figma team files: https://www.figma.com/files/1539002666003113376/team/1542064100377724261/Moodle-Design-System
 
 **When making any change:**
+
 - Do not edit or regenerate token files. `tokens/dtcg/**/*.json`, `tokens/css/**`, and `tokens/scss/**` are managed by the ZeroHeight PR flow — agents must not edit them directly or run `npm run build-tokens`.
 - Prefer extending existing component patterns; avoid new architectural layers, context providers, or state abstractions.
 - Do not add new npm dependencies unless the task explicitly requires an external package and no existing utility covers the need. Do not add icon or image packages — use assets provided by Figma MCP instead.

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -30,12 +30,12 @@ Consumers import from the package root only — subpath imports per component ar
 
 The following changes to a component's public API are breaking and must not be made without a major version bump:
 
-| Change | Why it breaks |
-|---|---|
-| Removing or renaming a prop | Existing callers pass the old name and get no value |
-| Narrowing a prop's type (e.g. `string` → `'a' \| 'b'`) | Valid values callers already pass become type errors |
-| Changing a prop's runtime behavior or default | Callers relying on the old default get a different result silently |
-| Removing or renaming an export | Import statements in consumer code stop resolving |
+| Change                                                     | Why it breaks                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Removing or renaming a prop                                | Existing callers pass the old name and get no value                     |
+| Narrowing a prop's type (e.g. `string` → `'a' \| 'b'`)     | Valid values callers already pass become type errors                    |
+| Changing a prop's runtime behavior or default              | Callers relying on the old default get a different result silently      |
+| Removing or renaming an export                             | Import statements in consumer code stop resolving                       |
 | Changing the root element type (e.g. `<button>` → `<div>`) | Breaks CSS selectors, ARIA roles, and event forwarding in consumer apps |
 
 Safe (non-breaking) changes: adding an optional prop with a default, widening a type, adding a new export, adding a value to `allowedVariants`.
@@ -87,7 +87,11 @@ const classes = ['mds-btn', 'btn', `btn-${resolvedVariant}`];
 if (size) classes.push(`btn-${size}`);
 if (className) classes.push(className);
 
-return <button className={classes.join(' ')} type={type} {...props}>{label}</button>;
+return (
+  <button className={classes.join(' ')} type={type} {...props}>
+    {label}
+  </button>
+);
 ```
 
 Spread `...props` last so consumers can pass `aria-*`, `data-*`, event handlers, and other native attributes through without explicit forwarding.
@@ -100,7 +104,7 @@ Moodle is available in 100+ languages and supports RTL scripts (Arabic, Hebrew, 
 
 ```tsx
 // ✅ correct
-<Button label={t('core:save')} />
+<Button label={t('core:save')} />;
 
 // ❌ wrong
 return <button>Save</button>;
@@ -108,13 +112,13 @@ return <button>Save</button>;
 
 **CSS logical properties:** Use logical properties instead of physical directional ones so layout mirrors correctly under RTL without extra CSS.
 
-| Avoid | Use instead |
-|---|---|
-| `margin-left` / `margin-right` | `margin-inline-start` / `margin-inline-end` |
-| `padding-left` / `padding-right` | `padding-inline-start` / `padding-inline-end` |
-| `left` / `right` (positioning) | `inset-inline-start` / `inset-inline-end` |
-| `border-left` / `border-right` | `border-inline-start` / `border-inline-end` |
-| `text-align: left` / `text-align: right` | `text-align: start` / `text-align: end` |
+| Avoid                                    | Use instead                                   |
+| ---------------------------------------- | --------------------------------------------- |
+| `margin-left` / `margin-right`           | `margin-inline-start` / `margin-inline-end`   |
+| `padding-left` / `padding-right`         | `padding-inline-start` / `padding-inline-end` |
+| `left` / `right` (positioning)           | `inset-inline-start` / `inset-inline-end`     |
+| `border-left` / `border-right`           | `border-inline-start` / `border-inline-end`   |
+| `text-align: left` / `text-align: right` | `text-align: start` / `text-align: end`       |
 
 Direction-neutral properties (`top`, `bottom`, `height`, `width`, `margin-top`, `padding-top`, etc.) do not need changing.
 

--- a/.github/instructions/stories-tests.instructions.md
+++ b/.github/instructions/stories-tests.instructions.md
@@ -18,6 +18,7 @@ Two things differ from standard Vitest/Testing Library — get these wrong and t
 - **Import `expect` from `'storybook/test'`**, not from `'vitest'` — they look identical but only the Storybook one works inside a `play` function.
 
 Everything else:
+
 - `userEvent` provides interactions: `userEvent.click()`, `userEvent.type()`, `userEvent.hover()`, etc.
 - Always `await` interactions and assertions.
 - Use `await new Promise(r => setTimeout(r, 0))` to flush the microtask queue if assertions fail spuriously after an interaction.
@@ -25,12 +26,12 @@ Everything else:
 
 ### Tags
 
-| Tag | Effect |
-|---|---|
-| `autodocs` | Generates an API documentation page for the component |
-| `test` | Includes the story in `npm run test-storybook` (Playwright/Chromium) |
-| `stable` | Informational — marks the story as production-ready |
-| `experimental` | Excludes the story from Storybook Vitest test runs |
+| Tag            | Effect                                                               |
+| -------------- | -------------------------------------------------------------------- |
+| `autodocs`     | Generates an API documentation page for the component                |
+| `test`         | Includes the story in `npm run test-storybook` (Playwright/Chromium) |
+| `stable`       | Informational — marks the story as production-ready                  |
+| `experimental` | Excludes the story from Storybook Vitest test runs                   |
 
 Default for new stories: `tags: ['autodocs', 'test', 'stable']`.
 
@@ -93,9 +94,9 @@ Story and test files (`*.stories.tsx`, `*.test.tsx`) are excluded from `tsconfig
 
 ## Test environment differences
 
-| Mode | Command | Runner | DOM | Includes |
-|---|---|---|---|---|
-| Unit | `npm run test-unit` | Vitest | jsdom | `components/**/*.{test,spec}.tsx` |
-| Storybook | `npm run test-storybook` | Vitest + Playwright | Chromium | Stories tagged `test` |
+| Mode      | Command                  | Runner              | DOM      | Includes                          |
+| --------- | ------------------------ | ------------------- | -------- | --------------------------------- |
+| Unit      | `npm run test-unit`      | Vitest              | jsdom    | `components/**/*.{test,spec}.tsx` |
+| Storybook | `npm run test-storybook` | Vitest + Playwright | Chromium | Stories tagged `test`             |
 
 Use unit tests for behavior contracts (class application, prop validation, prop forwarding). Use story `play` functions for user interactions and visual/a11y state.

--- a/.github/instructions/tokens.instructions.md
+++ b/.github/instructions/tokens.instructions.md
@@ -40,15 +40,15 @@ A custom transform (`dimension-px-to-rem`) converts `$type: "number"` dimension 
 
 Tokens follow a hierarchical naming pattern: `--mds-{category}-{subcategory}-{modifier}`
 
-| Category | Examples |
-|---|---|
-| Background | `--mds-bg-interactive-primary-default`, `--mds-bg-interactive-primary-hover`, `--mds-bg-interactive-primary-disabled` |
-| Text | `--mds-text-default`, `--mds-text-inverse`, `--mds-text-muted`, `--mds-text-danger` |
-| Border | `--mds-border-translucent`, `--mds-border-interactive-primary-default`, `--mds-border-radius-lg` |
-| Spacing | `--mds-spacing-xxs`, `--mds-spacing-xs`, `--mds-spacing-sm`, `--mds-spacing-md` |
+| Category   | Examples                                                                                                                                                        |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Background | `--mds-bg-interactive-primary-default`, `--mds-bg-interactive-primary-hover`, `--mds-bg-interactive-primary-disabled`                                           |
+| Text       | `--mds-text-default`, `--mds-text-inverse`, `--mds-text-muted`, `--mds-text-danger`                                                                             |
+| Border     | `--mds-border-translucent`, `--mds-border-interactive-primary-default`, `--mds-border-radius-lg`                                                                |
+| Spacing    | `--mds-spacing-xxs`, `--mds-spacing-xs`, `--mds-spacing-sm`, `--mds-spacing-md`                                                                                 |
 | Typography | `--mds-font-family-base`, `--mds-font-weight-regular`, `--mds-font-size-paragraph-default`, `--mds-line-height-paragraph-small`, `--mds-letter-spacing-default` |
-| Stroke | `--mds-stroke-weight-sm` |
-| Shadow | `--mds-shadow-lg` |
+| Stroke     | `--mds-stroke-weight-sm`                                                                                                                                        |
+| Shadow     | `--mds-shadow-lg`                                                                                                                                               |
 
 State variants follow the pattern `...-default`, `...-hover`, `...-active`, `...-disabled`.
 
@@ -68,11 +68,11 @@ Renaming or removing a token is a breaking change — consumer code referencing 
 
 The following changes must not be made without a major version bump:
 
-| Change | Why it breaks |
-|---|---|
-| Renaming a token | Any `var(--mds-old-name)` in consumer CSS stops resolving |
-| Removing a token | Same as above |
-| Changing a token's type or unit (e.g. `px` → `rem` at the source level) | Changes computed values in consumer layouts |
+| Change                                                                  | Why it breaks                                             |
+| ----------------------------------------------------------------------- | --------------------------------------------------------- |
+| Renaming a token                                                        | Any `var(--mds-old-name)` in consumer CSS stops resolving |
+| Removing a token                                                        | Same as above                                             |
+| Changing a token's type or unit (e.g. `px` → `rem` at the source level) | Changes computed values in consumer layouts               |
 
 Safe (non-breaking) changes: adding a new token, changing a token's value within the same type and unit.
 

--- a/.github/linters/eslint.config.mjs
+++ b/.github/linters/eslint.config.mjs
@@ -62,6 +62,14 @@ export default defineConfig(
       rules: {
         'react/react-in-jsx-scope': 'off',
         'react/prop-types': 'off',
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+        ],
+        '@typescript-eslint/consistent-type-definitions': [
+          'error',
+          'interface',
+        ],
         'prettier/prettier': [
           'error',
           {
@@ -71,6 +79,32 @@ export default defineConfig(
             printWidth: 80,
             tabWidth: 2,
             plugins: ['prettier-plugin-organize-imports'],
+          },
+        ],
+      },
+    },
+  ],
+  [
+    {
+      files: ['**/*.stories.tsx'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'vitest',
+                importNames: ['expect'],
+                message:
+                  "Import 'expect' from 'storybook/test' in story files.",
+              },
+              {
+                name: '@testing-library/react',
+                importNames: ['screen'],
+                message:
+                  "Use 'canvas' from the Storybook play function context instead of 'screen'.",
+              },
+            ],
           },
         ],
       },

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -56,6 +56,31 @@ jobs:
         env:
           SB_URL: '${{ github.event.deployment_status.environment_url }}'
 
+  lint-format-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Clean install
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+
+      - name: Lint
+        run: npx eslint . --ext .ts,.tsx,.js,.jsx --config .github/linters/eslint.config.mjs
+
+      - name: Format check
+        # --check exits non-zero if any file differs from Prettier's output, failing the build.
+        run: npx prettier --config .github/linters/.prettierrc --ignore-path .github/linters/.prettierignore --check . '**/*.{ts,tsx,js,jsx,yml}'
+
+      - name: Build
+        run: npm run build
+
   chromatic:
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest

--- a/components/button/Button.test.tsx
+++ b/components/button/Button.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 import { fuzzComponent } from '../../tests/utils/fuzzComponent';
-import { Button, ButtonProps } from './Button';
+import { Button, type ButtonProps } from './Button';
 
 const fuzzLabelCharacters =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;:'<>.,.?/";

--- a/package-lock.json
+++ b/package-lock.json
@@ -5079,23 +5079,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -5126,13 +5109,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -5711,6 +5687,13 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -6850,9 +6833,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10598,6 +10581,23 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -12027,13 +12027,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",

--- a/scripts/tokens.ts
+++ b/scripts/tokens.ts
@@ -14,7 +14,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 import fs from 'fs';
-import StyleDictionary, { TransformedToken } from 'style-dictionary';
+import StyleDictionary, { type TransformedToken } from 'style-dictionary';
 
 const tokenFiles = fs
   .readdirSync('tokens/dtcg')

--- a/tests/utils/fuzzComponent.ts
+++ b/tests/utils/fuzzComponent.ts
@@ -8,7 +8,7 @@
 
 import { render, screen } from '@testing-library/react';
 import fc from 'fast-check';
-import React, { ComponentType } from 'react';
+import React, { type ComponentType } from 'react';
 
 /**
  * Runs property-based fuzzing on a React component.


### PR DESCRIPTION
## Description

Operationalises the end-to-end component build checklist (MDS-439) for the development side of the process. Establishes which checklist items are CI-enforced, which are author self-checked via PR template, and which are reviewer-verified — so the team has a consistent, documented way of working through the checklist for every component built.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-509

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [x] Other: CI and process

## Screenshots/Previews

No UI changes.

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
  - Three pre-existing `import type` violations auto-fixed in `Button.test.tsx`, `scripts/tokens.ts`, and `tests/utils/fuzzComponent.ts`
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate) — not applicable
- [ ] I have considered accessibility and described any improvements or issues — not applicable
- [ ] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant — no security implications
- [x] Breaking change assessment complete — no props, exports, or tokens changed
- [x] Instruction files updated if this change introduces new patterns or anti-patterns — instruction files reformatted and updated as part of this PR

## Additional Notes

### What this PR does

**CI (`testing.yml`)** — adds a `lint-format-build` job that runs ESLint (check-only), Prettier (check-only), and `npm run build` on every PR targeting `main`. These three checks were listed as required in checklist item 23 but had no CI enforcement.

**ESLint (`.github/linters/eslint.config.mjs`)** — adds three rules using already-installed plugins, no new dependencies:

| Rule | Scope | Enforces |
| --- | --- | --- |
| `@typescript-eslint/consistent-type-imports` | All files | `import type` for type-only imports |
| `@typescript-eslint/consistent-type-definitions` | All files | `interface` over `type` for props |
| `no-restricted-imports` | `*.stories.tsx` only | `expect` from `storybook/test`; `canvas` over `screen` |

**PR templates** — splits the single template into two:

- `.github/PULL_REQUEST_TEMPLATE.md` — lean catch-all for bugfixes, refactors, and docs
- `.github/PULL_REQUEST_TEMPLATE/component.md` — full component author checklist covering file structure, TypeScript/props, i18n, CSS/tokens, tests/stories, breaking changes, AI context, and cross-system parity. Selected via `?template=component.md` on the PR URL.

**`CONTRIBUTING.md`** — adds a component checklist enforcement section mapping each item to its enforcement level (CI, author, reviewer, or role sign-off), and documents how to select the component PR template.

### Known remaining gaps

Two checklist items remain process-covered only and are candidates for follow-up tasks:

- **Item 18 (i18n) / Item 19 (CSS tokens)** — Stylelint with `stylelint-use-logical` and a no-hardcoded-values rule would automate enforcement of logical CSS properties and `var(--mds-*)` token usage respectively
- **Item 21 (stories)** — `@vitest/eslint-plugin` `no-disabled-tests` would block bare `it.skip`/`describe.skip` at lint time
