### PR TITLE
feat: Add status marker for components on storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -20,6 +20,7 @@ export default {
       options: coverageConfig,
     },
     '@storybook/addon-themes',
+    '@etchteam/storybook-addon-status',
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/components/button/Button.stories.tsx
+++ b/components/button/Button.stories.tsx
@@ -7,13 +7,6 @@ const meta = {
   component: Button,
   parameters: {
     layout: 'centered',
-    docs: {
-      description: {
-        component: `
-⚠️ **This component is under development and not production ready.** API may change without notice.
-        `,
-      },
-    },
   },
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { label: 'Button' }));
@@ -21,7 +14,7 @@ const meta = {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await expect(canvas.getByText('Button')).toBeVisible();
   },
-  tags: ['autodocs', 'test', 'stable'],
+  tags: ['autodocs', 'test', 'beta'],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
   argTypes: {
     label: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@eslint/compat": "^2.0.0",
         "@eslint/eslintrc": "^3.3.3",
         "@eslint/js": "^10.0.1",
+        "@etchteam/storybook-addon-status": "^8.0.0",
         "@storybook/addon-a11y": "^10.1.2",
         "@storybook/addon-coverage": "^3.0.0",
         "@storybook/addon-docs": "^10.1.2",
@@ -1591,6 +1592,19 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@etchteam/storybook-addon-status": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@etchteam/storybook-addon-status/-/storybook-addon-status-8.0.0.tgz",
+      "integrity": "sha512-PR0qiT5ndB32rfRi3a6QJE66sUuTD2GeJMmQFdaEOLjTWuJ/usdZ6hXXCmWadPLZXcg6wkvHGFQxDSOKNVjU9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "storybook": "^10.0.0"
       }
     },
     "node_modules/@exodus/bytes": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@eslint/compat": "^2.0.0",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^10.0.1",
+    "@etchteam/storybook-addon-status": "^8.0.0",
     "@storybook/addon-a11y": "^10.1.2",
     "@storybook/addon-coverage": "^3.0.0",
     "@storybook/addon-docs": "^10.1.2",


### PR DESCRIPTION
## Description

Implement a status marker on Storybook for components to indicate their readiness for the consumer. Storybook itself doesnt have an in-house addon for that, hence we would need a community addon for that.

The chosen addon is `@etchteam/storybook-addon-status`

Why this one?
- This addon appears in the integrations list within Storybook https://storybook.js.org/addons/@etchteam/storybook-addon-status
- It has the most downloads compared to other addons - the weekly downloads in NPM are 101,044
- Actively maintained with the latest release from 5 months ago

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-469

## Type of Change

- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

<img width="1106" height="655" alt="Screenshot 2026-04-06 at 4 13 55 pm" src="https://github.com/user-attachments/assets/e214f69e-03f9-473e-96de-47e832606006" />

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

N/A