### PR TITLE
chore(CICD): Update Playwright to latest version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       # Make sure to grab the latest version of the Playwright image
       # https://playwright.dev/docs/docker#pull-the-image
-      image: mcr.microsoft.com/playwright:v1.58.0-noble
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 


### PR DESCRIPTION
## Description

Bumps the Playwright Docker image used in CI from `v1.58.0-noble` to `v1.59.1-noble` to keep the test environment on the latest stable release.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-529

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [x] Other (dependency update)

## Screenshots/Previews

N/A — no UI changes.

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

Single-line change to `.github/workflows/testing.yml`. The image tag is pinned rather than using `latest` per the [Playwright Docker docs](https://playwright.dev/docs/docker#pull-the-image); this bump keeps it current while retaining that pin.
