### PR TITLE
feat(components)!: Component library foundations — build, Button API, and authoring guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,19 +3,23 @@
 ## Project shape (read first)
 
 - This is a React + TypeScript component library built with Vite library mode; public entrypoint is `index.ts` and package exports are defined in `package.json`.
+- The build uses Rollup's `preserveModules` mode: every source file is transpiled in isolation into its own stable, hash-free output file. This is intentional — Moodle loads files directly by URL without a consumer-side build step, so output paths must be predictable across releases.
 - Runtime styling flow is: `index.ts` imports Bootstrap base CSS, generated design tokens (`tokens/css/index.css`), then component styles (`components/index.css`). Keep this order.
 - Components apply Bootstrap CSS classes directly in JSX (no `react-bootstrap` dependency). Each component adds a stable `mds-*` class hook and is styled via `--mds-*` CSS custom properties in a colocated CSS file.
 - Token sources are DTCG JSON in `tokens/dtcg/`; generated outputs in `tokens/css/` and `tokens/scss/` are produced by `scripts/tokens.ts` via Style Dictionary.
 
 Published package exports:
 
-| Import                                       | Resolves to                      |
-| -------------------------------------------- | -------------------------------- |
-| `@moodlehq/design-system`                    | `dist/index.js`                  |
-| `@moodlehq/design-system/css`                | `dist/index.css`                 |
-| `@moodlehq/design-system/tokens/css`         | `tokens/css/index.css`           |
-| `@moodlehq/design-system/tokens/scss`        | `tokens/scss/_index.scss`        |
-| `@moodlehq/design-system/tokens/scss/legacy` | `tokens/scss/_index.legacy.scss` |
+| Import                                       | Resolves to                       |
+| -------------------------------------------- | --------------------------------- |
+| `@moodlehq/design-system`                    | `dist/index.js`                   |
+| `@moodlehq/design-system/css`                | `dist/index.css`                  |
+| `@moodlehq/design-system/components/<name>`  | `dist/components/<name>/index.js` |
+| `@moodlehq/design-system/tokens/css`         | `tokens/css/index.css`            |
+| `@moodlehq/design-system/tokens/scss`        | `tokens/scss/_index.scss`         |
+| `@moodlehq/design-system/tokens/scss/legacy` | `tokens/scss/_index.legacy.scss`  |
+
+Component subpath imports are auto-discovered at build time — adding a new folder under `components/` is sufficient; no changes to `package.json` or `vite.config.ts` are needed.
 
 ## Path-specific instruction files
 

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -24,7 +24,48 @@ export { Button } from './button';
 export type { ButtonProps } from './button';
 ```
 
-Consumers import from the package root only — subpath imports per component are not supported.
+Consumers import from the package root using named imports:
+
+```ts
+import { Button } from '@moodlehq/design-system';
+```
+
+Named re-exports (`export { Button }`) are sufficient for ESM tree-shaking — avoid `export { default as Button }` in barrel files.
+
+## Composition pattern
+
+**Simple components** (single root element, no internal structure): use flat props. Accept all content via named string props rather than `children`. This keeps the API explicit, ensures all text is explicitly caller-supplied, and is straightforward to document.
+
+Two separate rules apply:
+
+1. **Named props over `children`** — simple components do not render `children`; passing children will be silently ignored.
+2. **No raw string literals** — named prop values must be caller-supplied (e.g. from `t()`) so the consuming app controls translation. Raw string literals hardcode English text in the component and bypass the i18n contract.
+
+```tsx
+// ✅ correct — named prop, caller supplies the translated string
+<Button label={t('core:save')} variant="primary" />
+
+// ❌ wrong — raw string literal as a named prop value, not translatable
+<Button label="Save" variant="primary" />
+
+// ❌ wrong — children are not rendered by simple components
+<Button>Save</Button>
+<Button>{t('core:save')}</Button>
+```
+
+**Compound components** (components with distinct named regions — e.g. a card with a header, body, and footer): export each sub-component as a named export from the component's barrel. Do not use dot-notation (`Card.Header`) — named exports are tree-shakeable and align with the existing barrel pattern.
+
+```tsx
+// components/card/index.tsx
+export { Card } from './Card';
+export { CardHeader } from './CardHeader';
+export { CardBody } from './CardBody';
+
+// Consumer
+import { Card, CardHeader, CardBody } from '@moodlehq/design-system';
+```
+
+Each sub-component follows the same file structure rules as any other component and must have its own stories and tests.
 
 ## Breaking change guardrail
 
@@ -51,7 +92,7 @@ import type { ButtonHTMLAttributes } from 'react';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
-  variant?: string; // intentionally broad — see runtime validation below
+  variant?: ButtonVariant; // use the union type; runtime validation still guards JS consumers
   size?: 'sm' | 'lg';
 }
 ```
@@ -60,18 +101,32 @@ Use `interface`, not `type`, for props. Use `import type` for type-only imports.
 
 ## Runtime validation for constrained props
 
-Props with a fixed set of allowed values must use runtime validation with an `allowedValues` array — TypeScript types alone are not enough, because external consumers can pass any string. Accept the prop as a broad type (`string`) in the interface and resolve to a safe default if an invalid value arrives:
+Props with a fixed set of allowed values must use runtime validation with an `allowedValues` array — TypeScript types alone are not enough, because external consumers can pass any string. Accept the prop as a broad type (`string`) in the interface and resolve to a safe default if an invalid value arrives.
+
+Always pair the silent fallback with a development-mode warning so consumers are alerted without affecting production builds:
 
 ```ts
 type ButtonVariant = 'primary' | 'secondary' | 'danger';
 const allowedVariants: ButtonVariant[] = ['primary', 'secondary', 'danger'];
 
 // In the component body:
+if (
+  import.meta.env.DEV &&
+  variant &&
+  !allowedVariants.includes(variant as ButtonVariant)
+) {
+  console.warn(
+    `[MDS Button] Invalid variant "${variant}". Falling back to "primary". Allowed: ${allowedVariants.join(', ')}`,
+  );
+}
+
 const resolvedVariant =
   variant && allowedVariants.includes(variant as ButtonVariant)
     ? variant
     : 'primary'; // fallback to default
 ```
+
+The `import.meta.env.DEV` guard ensures the warning is tree-shaken from production builds. Adapt the component name and prop name in the warning message for each component.
 
 ## Class composition
 

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -24,13 +24,18 @@ export { Button } from './button';
 export type { ButtonProps } from './button';
 ```
 
-Consumers import from the package root using named imports:
+Consumers can import from the package root or using a component subpath:
 
 ```ts
+// Full package — includes all components
 import { Button } from '@moodlehq/design-system';
+
+// Subpath — JS only; pair with a one-time CSS import in the app
+import { Button } from '@moodlehq/design-system/components/button';
+import '@moodlehq/design-system/css';
 ```
 
-Named re-exports (`export { Button }`) are sufficient for ESM tree-shaking — avoid `export { default as Button }` in barrel files.
+Named re-exports (`export { Button }`) are the correct form — avoid `export { default as Button }` in barrel files. The build uses `preserveModules`, so each source file becomes its own stable output file. Selective loading is achieved at the URL level (only import what you need) rather than via a bundler tree-shaker.
 
 ## Composition pattern
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -88,11 +88,7 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-        env:
-          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
-          CHROMATIC_SLUG: ${{ github.repository }}
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -108,5 +104,10 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+          storybookBaseDir: '.'
           autoAcceptChanges: 'main'
           skip: 'dependabot/**'
+        env:
+          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          CHROMATIC_SLUG: ${{ github.repository }}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,7 +2,9 @@
 
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
-import '../index';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import '../components/index.css';
+import '../tokens/css/index.css';
 import './preview.css';
 
 const preview = {

--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ export default function App() {
 }
 ```
 
-> **Note:** Subpath imports such as `@moodlehq/design-system/button` are not currently supported. Please import components from `@moodlehq/design-system`.
+Components can also be imported individually via subpath imports. This is useful when loading files directly by URL (e.g. in Moodle plugins), as only the requested component is fetched:
+
+```js
+import '@moodlehq/design-system/css';
+import { Button } from '@moodlehq/design-system/components/button';
+```
 
 ### Fonts
 

--- a/components/button/Button.test.tsx
+++ b/components/button/Button.test.tsx
@@ -31,8 +31,19 @@ describe('Button: Unit Test', () => {
   });
 
   it('handles invalid variant prop as default variant', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     render(<Button label="Button" variant="invalid" />);
     expect(screen.getByRole('button')).toHaveClass('btn-primary');
+    vi.restoreAllMocks();
+  });
+
+  it('warns in development when an invalid variant is passed', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<Button label="Button" variant="invalid" />);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[MDS Button] Invalid variant "invalid"'),
+    );
+    vi.restoreAllMocks();
   });
 
   it('applies the size classes', () => {

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -13,7 +13,7 @@ type IconElement = ReactElement<'i' | 'svg'>;
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   label?: string;
-  variant?: string;
+  variant?: ButtonVariant;
   size?: 'sm' | 'lg';
   startIcon?: IconElement;
   endIcon?: IconElement;
@@ -54,6 +54,11 @@ export const Button = ({
     if (!hasLabel && !hasAriaLabel) {
       console.warn(
         'Button: label prop or aria-label attribute is required for accessibility.',
+      );
+    }
+    if (variant && !allowedVariants.includes(variant as ButtonVariant)) {
+      console.warn(
+        `[MDS Button] Invalid variant "${variant}". Falling back to "primary". Allowed: ${allowedVariants.join(', ')}`,
       );
     }
   }

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -1,3 +1,3 @@
-import './button.css';
-
+// CSS is aggregated via components/index.css and imported by the package root entry (index.ts).
+// It is intentionally omitted here so per-component subpath imports remain side-effect-free for JS consumers.
 export * from './Button';

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -1,1 +1,3 @@
+import './button.css';
+
 export * from './Button';

--- a/css.d.ts
+++ b/css.d.ts
@@ -1,0 +1,5 @@
+// Required: TypeScript >= 5.6 with moduleResolution "bundler" and
+// noUncheckedSideEffectImports: true treats a missing `types` condition on a
+// package export as a hard error. This declaration satisfies that check for
+// the side-effect-only CSS import: import '@moodlehq/design-system/css'
+declare module '@moodlehq/design-system/css' {}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "files": [
     "/dist",
     "/tokens/css",
-    "/tokens/scss"
+    "/tokens/scss",
+    "/css.d.ts"
   ],
   "exports": {
     ".": {
@@ -13,6 +14,7 @@
       "import": "./dist/index.js"
     },
     "./css": {
+      "types": "./css.d.ts",
       "default": "./dist/index.css"
     },
     "./tokens/css": {
@@ -26,6 +28,9 @@
     }
   },
   "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "dependencies": {
     "bootstrap": "^5.3.8"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
       "types": "./css.d.ts",
       "default": "./dist/index.css"
     },
+    "./components/*": {
+      "types": "./dist/components/*/index.d.ts",
+      "import": "./dist/components/*/index.js"
+    },
     "./tokens/css": {
       "default": "./tokens/css/index.css"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "noUnusedLocals": true, // Flags unused local variables.
     "noUnusedParameters": true, // Flags unused function parameters.
     "noFallthroughCasesInSwitch": true, // Requires handling all cases in a switch statement.
-    "declaration": true // Generates declaration files for TypeScript.
+    "declaration": true, // Generates declaration files for TypeScript.
+    "types": ["vite/client"] // Provides ImportMeta.env typings from Vite.
   },
   "include": ["components", "index.ts"], // Specifies the directory to include when searching for TypeScript files.
   "exclude": ["components/**/*.stories.tsx", "components/**/*.test.tsx"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,12 +6,25 @@ import dts from 'vite-plugin-dts';
 // https://vite.dev/config/
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 const dirname =
   typeof __dirname !== 'undefined'
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
+
+// Automatically discover one entry per component directory so new components
+// are included in the build without any manual configuration changes.
+const componentEntries = Object.fromEntries(
+  fs
+    .readdirSync(path.join(dirname, 'components'), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => [
+      `components/${d.name}/index`,
+      `./components/${d.name}/index.tsx`,
+    ]),
+);
 
 export default defineConfig({
   plugins: [react(), dts()], // Uses the 'vite-plugin-dts' plugin for generating TypeScript declaration files (d.ts).
@@ -20,9 +33,14 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: './index.ts', // Specifies the entry point for building the library.
-      name: 'moodle-design-system', // Sets the name of the generated library.
-      fileName: () => 'index.js', // Generates a format-agnostic output file name.
+      // Multiple entry points: one for the full package, one per component subpath.
+      // Each key becomes the output file path under dist/ (e.g. dist/components/button/index.js).
+      entry: {
+        index: './index.ts',
+        ...componentEntries,
+      },
+      name: 'moodle-design-system',
+      fileName: (_, entryName) => `${entryName}.js`, // Preserve entry path as output filename.
       formats: ['es'], // Specifies the output format (ES modules only).
     },
     cssCodeSplit: false, // bundle all CSS into a single file
@@ -30,6 +48,12 @@ export default defineConfig({
       external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime'],
       output: {
         assetFileNames: 'index.css', // name the CSS file
+        // Transpile every source file into its own output file with a stable, predictable
+        // path — no chunk splitting, no content hashes. This matches Moodle's loading model
+        // where files are served directly by URL without a consumer-side build step.
+        preserveModules: true,
+        preserveModulesRoot: '.',
+        entryFileNames: '[name].js',
       },
     },
     sourcemap: true, // Generates source maps for debugging.


### PR DESCRIPTION
## Description

This PR makes three related improvements:

**1. Component subpath imports**

Each component can now be imported individually via a stable subpath, in addition to the existing full-package import:

```js
// Full package (all components)
import { Button } from '@moodlehq/design-system';

// Component subpath (only Button is fetched)
import { Button } from '@moodlehq/design-system/components/button';

// Direct URL — no build step needed (e.g. Moodle plugins)
import { Button } from 'https://cdn.example.com/mds/dist/components/button/index.js';
```

The build now uses Rollup's `preserveModules` mode — every source file is transpiled in isolation into its own stable, hash-free output file. This matches Moodle's loading model: plugins load files directly by URL without a consumer-side build step, so output paths must remain predictable across releases. Adding a new component folder under `components/` is sufficient to include it in the build — no changes to `package.json` or `vite.config.ts` are needed.

**2. Button variant type narrowing (breaking)**

`ButtonProps.variant` is now typed as `ButtonVariant` (a string union of the six supported values) instead of `string`. Consumers passing an arbitrary string will get a TypeScript error at compile time. Runtime behaviour is unchanged — invalid values still fall back to `"primary"` with a `console.warn` in development.

**3. CI/CD — Chromatic TurboSnap fix**

Corrects Chromatic settings in the testing workflow to ensure TurboSnap functions correctly.

## Related Jira or GitHub Issue

<!-- Link to related issues or tickets (e.g., https://moodle.atlassian.net/browse/MDS-522) -->

## Type of Change

- [x] Feature
- [x] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

<!-- Reference Chromatic visual diffs if applicable. No visual changes are expected from this PR. -->

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — `ButtonProps.variant` narrowed from `string` to `ButtonVariant`; runtime behaviour unchanged, type errors at compile time for consumers passing arbitrary strings
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

<!-- Add any other context or information reviewers should know -->
