### PR TITLE
feat(icons): Add fontawesome for storybook

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,6 @@
 /** @type { import('@storybook/react-vite').Preview } */
 
+import '@fortawesome/fontawesome-free/css/all.min.css';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import '../index';
 import './preview.css';

--- a/components/button/Button.stories.tsx
+++ b/components/button/Button.stories.tsx
@@ -2,6 +2,16 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 import { Button } from './Button';
 
+const iconMapping = {
+  None: undefined,
+  Download: <i className="fa-solid fa-download" aria-hidden="true" />,
+  Trash: <i className="fa-solid fa-trash" aria-hidden="true" />,
+  'Arrow Right': <i className="fa-solid fa-arrow-right" aria-hidden="true" />,
+  'Arrow Left': <i className="fa-solid fa-arrow-left" aria-hidden="true" />,
+  Plus: <i className="fa-solid fa-plus" aria-hidden="true" />,
+  Check: <i className="fa-solid fa-check" aria-hidden="true" />,
+};
+
 const meta = {
   title: 'Components/Button',
   component: Button,
@@ -9,10 +19,10 @@ const meta = {
     layout: 'centered',
   },
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByRole('button', { label: 'Button' }));
+    await userEvent.click(canvas.getByRole('button'));
     // Wait for any updates to complete
     await new Promise((resolve) => setTimeout(resolve, 0));
-    await expect(canvas.getByText('Button')).toBeVisible();
+    await expect(canvas.getByRole('button')).toBeVisible();
   },
   tags: ['autodocs', 'test', 'beta'],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
@@ -50,6 +60,20 @@ const meta = {
         type: { summary: 'sm | lg' },
         defaultValue: { summary: 'undefined' },
       },
+    },
+    startIcon: {
+      description:
+        'Icon rendered before the label. Accepts only intrinsic `<i>` or `<svg>` elements. Mark decorative icons with `aria-hidden="true"`. For icon-only buttons pass `aria-label` directly.',
+      options: Object.keys(iconMapping),
+      mapping: iconMapping,
+      control: { type: 'select' },
+    },
+    endIcon: {
+      description:
+        'Icon rendered after the label. Accepts only intrinsic `<i>` or `<svg>` elements. Mark decorative icons with `aria-hidden="true"`. For icon-only buttons pass `aria-label` directly.',
+      options: Object.keys(iconMapping),
+      mapping: iconMapping,
+      control: { type: 'select' },
     },
     disabled: {
       control: { type: 'boolean' },
@@ -148,4 +172,40 @@ export const Small = {
     size: 'sm',
     label: 'Button',
   },
+} satisfies Story;
+
+export const WithLeadingIcon: Story = {
+  args: {
+    label: 'Download',
+    startIcon: <i className="fa-solid fa-download" aria-hidden="true" />,
+  },
+} satisfies Story;
+
+export const WithTrailingIcon: Story = {
+  args: {
+    label: 'Continue',
+    endIcon: <i className="fa-solid fa-arrow-right" aria-hidden="true" />,
+  },
+} satisfies Story;
+
+export const IconOnly: Story = {
+  args: {
+    label: '',
+    startIcon: <i className="fa-solid fa-trash" aria-hidden="true" />,
+    'aria-label': 'Delete',
+  },
+} satisfies Story;
+
+export const RightToLeft: Story = {
+  tags: ['test'],
+  args: {
+    label: 'Continue',
+    startIcon: <i className="fa-solid fa-arrow-right" aria-hidden="true" />,
+    endIcon: <i className="fa-solid fa-arrow-left" aria-hidden="true" />,
+  },
+  render: (args) => (
+    <div dir="rtl">
+      <Button {...args} />
+    </div>
+  ),
 } satisfies Story;

--- a/components/button/Button.test.tsx
+++ b/components/button/Button.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import fc from 'fast-check';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { fuzzComponent } from '../../tests/utils/fuzzComponent';
 import { Button, type ButtonProps } from './Button';
 
@@ -38,6 +38,136 @@ describe('Button: Unit Test', () => {
   it('applies the size classes', () => {
     render(<Button label="Button" size="lg" />);
     expect(screen.getByRole('button')).toHaveClass('btn-lg');
+  });
+
+  it('renders startIcon before the label and endIcon after the label', () => {
+    render(
+      <Button
+        label="Button"
+        startIcon={<i data-testid="start-icon" aria-hidden="true" />}
+        endIcon={
+          <svg data-testid="end-icon" aria-hidden="true" viewBox="0 0 1 1" />
+        }
+      />,
+    );
+
+    const button = screen.getByRole('button');
+    const startIcon = screen.getByTestId('start-icon');
+    const endIcon = screen.getByTestId('end-icon');
+
+    expect(button).toContainElement(startIcon);
+    expect(button).toContainElement(endIcon);
+    expect(
+      startIcon.compareDocumentPosition(endIcon) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('supports icon-only usage with an aria-label', () => {
+    render(
+      <Button
+        startIcon={<i data-testid="start-icon" aria-hidden="true" />}
+        aria-label="Delete"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Delete' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent(/^\s*$/);
+  });
+
+  it('renders only startIcon with no endIcon markup when endIcon is omitted', () => {
+    render(
+      <Button
+        label="Save"
+        startIcon={<i data-testid="start-icon" aria-hidden="true" />}
+      />,
+    );
+
+    expect(screen.getByTestId('start-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('end-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders only endIcon with no startIcon markup when startIcon is omitted', () => {
+    render(
+      <Button
+        label="Next"
+        endIcon={<i data-testid="end-icon" aria-hidden="true" />}
+      />,
+    );
+
+    expect(screen.getByTestId('end-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('start-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders no icon elements when neither startIcon nor endIcon is provided', () => {
+    render(<Button label="Submit" />);
+
+    const button = screen.getByRole('button');
+    const elementChildren = Array.from(button.childNodes).filter(
+      (n) => n.nodeType === Node.ELEMENT_NODE,
+    );
+    expect(elementChildren).toHaveLength(0);
+  });
+
+  it('accessible name matches only the label when startIcon is aria-hidden', () => {
+    render(
+      <Button
+        label="Download"
+        startIcon={<i className="fa-solid fa-download" aria-hidden="true" />}
+      />,
+    );
+
+    // Accessible name must be exactly the label — aria-hidden icon must not contribute.
+    expect(
+      screen.getByRole('button', { name: 'Download' }),
+    ).toBeInTheDocument();
+  });
+
+  it('accepts only <i> and <svg> elements as icons', () => {
+    // IconElement type is enforced at compile time; this test asserts the
+    // rendered tag names are what the type constraint documents them to be.
+    render(
+      <Button
+        label="Edit"
+        startIcon={<i data-testid="start-icon" aria-hidden="true" />}
+        endIcon={
+          <svg data-testid="end-icon" aria-hidden="true" viewBox="0 0 1 1" />
+        }
+      />,
+    );
+
+    expect(screen.getByTestId('start-icon').tagName).toBe('I');
+    expect(screen.getByTestId('end-icon').tagName).toBe('svg');
+  });
+
+  it('logs a console.error and drops non-<i>/<svg> elements passed as icons at runtime', () => {
+    // TypeScript prevents this at compile time, but JS consumers can bypass
+    // the type. The runtime guard must log an error and drop the element.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <Button
+        label="Edit"
+        startIcon={
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (<span data-testid="bad-start-icon" />) as any
+        }
+        endIcon={
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (<div data-testid="bad-end-icon" />) as any
+        }
+      />,
+    );
+
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy.mock.calls[0][0]).toMatch(/startIcon/);
+    expect(errorSpy.mock.calls[1][0]).toMatch(/endIcon/);
+    expect(screen.queryByTestId('bad-start-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bad-end-icon')).not.toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveTextContent('Edit');
+
+    errorSpy.mockRestore();
   });
 
   it('respects disabled prop', () => {
@@ -85,5 +215,14 @@ describe('Button: Unit Test', () => {
       // Run 100 generated cases for a good speed/coverage balance.
       { numRuns: 100 },
     );
+  });
+
+  it('warns in dev when no label and no aria-label', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+    render(<Button />);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Button: label prop or aria-label attribute is required for accessibility.',
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -1,4 +1,5 @@
-import type { ButtonHTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes, ReactElement } from 'react';
+import { isValidElement } from 'react';
 
 type ButtonVariant =
   | 'primary'
@@ -8,11 +9,24 @@ type ButtonVariant =
   | 'outline-secondary'
   | 'outline-danger';
 
+type IconElement = ReactElement<'i' | 'svg'>;
+
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  label: string;
+  label?: string;
   variant?: string;
   size?: 'sm' | 'lg';
+  startIcon?: IconElement;
+  endIcon?: IconElement;
 }
+
+// Runtime guard — prop for icons must be <i> or <svg> elements
+const isIconElement = (el: unknown, propName: string): el is IconElement => {
+  const valid = isValidElement(el) && (el.type === 'i' || el.type === 'svg');
+  if (!valid && el != null && import.meta.env.DEV) {
+    console.error(`Button: \`${propName}\` must be an <i> or <svg> element.`);
+  }
+  return valid;
+};
 
 const allowedVariants: ButtonVariant[] = [
   'primary',
@@ -27,10 +41,23 @@ export const Button = ({
   label,
   variant,
   size,
+  startIcon,
+  endIcon,
   className,
   type = 'button',
   ...props
 }: ButtonProps) => {
+  // Warn in development if button has no accessible name
+  if (import.meta.env.DEV) {
+    const hasLabel = Boolean(label);
+    const hasAriaLabel = 'aria-label' in props;
+    if (!hasLabel && !hasAriaLabel) {
+      console.warn(
+        'Button: label prop or aria-label attribute is required for accessibility.',
+      );
+    }
+  }
+
   const resolvedVariant =
     variant && allowedVariants.includes(variant as ButtonVariant)
       ? variant
@@ -46,7 +73,9 @@ export const Button = ({
 
   return (
     <button className={classes.join(' ')} type={type} {...props}>
+      {isIconElement(startIcon, 'startIcon') ? startIcon : null}
       {label}
+      {isIconElement(endIcon, 'endIcon') ? endIcon : null}
     </button>
   );
 };

--- a/components/button/button.css
+++ b/components/button/button.css
@@ -10,6 +10,12 @@
   font-size: var(--mds-font-size-paragraph-default);
   line-height: var(--mds-line-height-paragraph-small);
   letter-spacing: var(--mds-letter-spacing-default);
+
+  /* gap provides consistent spacing between startIcon/endIcon and label text;
+     has no visual effect when the button contains only a single child (no icon) */
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mds-spacing-xxs);
 }
 .mds-btn.btn:hover {
   background-color: var(--mds-bg-interactive-primary-hover);

--- a/components/vite-env.d.ts
+++ b/components/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@eslint/eslintrc": "^3.3.3",
         "@eslint/js": "^10.0.1",
         "@etchteam/storybook-addon-status": "^8.0.0",
+        "@fortawesome/fontawesome-free": "^7.2.0",
         "@storybook/addon-a11y": "^10.1.2",
         "@storybook/addon-coverage": "^3.0.0",
         "@storybook/addon-docs": "^10.1.2",
@@ -1635,6 +1636,16 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz",
+      "integrity": "sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==",
+      "dev": true,
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^10.0.1",
     "@etchteam/storybook-addon-status": "^8.0.0",
+    "@fortawesome/fontawesome-free": "^7.2.0",
     "@storybook/addon-a11y": "^10.1.2",
     "@storybook/addon-coverage": "^3.0.0",
     "@storybook/addon-docs": "^10.1.2",


### PR DESCRIPTION
## Description

- Added `@fortawesome/fontawesome-free` package as a dev dependency
- It is not bundled into the published package - with the purpose of having the consumer's freedom to choose their own icon providers.
- Button components are updated swiftly
  - To show the intended usage of the Fontawesome package in the repository
  - Considered to have as props to be strict on the icon positioning, while opening the option for any icons injected
  - CSS changes are minimal and will be revisited in https://moodle.atlassian.net/browse/MDS-266
- Unit test updated slightly to accommodate the situation where the label of the button would be dynamic 

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-480

## Type of Change

- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews
<img width="817" height="862" alt="Screenshot 2026-04-10 at 11 30 30 am" src="https://github.com/user-attachments/assets/218a1318-f14d-4399-b678-d9fc719e96c4" />

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes
N/A
