### PR TITLE
chore: Set Radio & Close to stable in stories

### DIFF
--- a/components/close-button/CloseButton.stories.tsx
+++ b/components/close-button/CloseButton.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs', 'test', 'beta'],
+  tags: ['autodocs', 'test', 'stable'],
   argTypes: {
     'aria-label': {
       control: { type: 'text' },

--- a/components/radio/Radio.figma.tsx
+++ b/components/radio/Radio.figma.tsx
@@ -9,8 +9,8 @@ figma.connect(Radio, url, {
   variant: { State: 'Default' },
   props: {
     label: figma.string('Label'),
-    // Figma "Show Label" true means the label is visible; hideLabel is its inverse.
-    hideLabel: figma.boolean('Show Label', { true: false, false: true }),
+    // Figma boolean 'Label' true means the label is visible; hideLabel is its inverse.
+    hideLabel: figma.boolean('Label', { true: false, false: true }),
     checked: figma.enum('Selected', { Yes: true }),
   },
   example: ({ label, hideLabel, checked }) => (
@@ -23,7 +23,7 @@ figma.connect(Radio, url, {
   variant: { State: 'Invalid', 'Show feedback text': false },
   props: {
     label: figma.string('Label'),
-    hideLabel: figma.boolean('Show Label', { true: false, false: true }),
+    hideLabel: figma.boolean('Label', { true: false, false: true }),
     checked: figma.enum('Selected', { Yes: true }),
   },
   example: ({ label, hideLabel, checked }) => (
@@ -36,7 +36,7 @@ figma.connect(Radio, url, {
   variant: { State: 'Invalid', 'Show feedback text': true },
   props: {
     label: figma.string('Label'),
-    hideLabel: figma.boolean('Show Label', { true: false, false: true }),
+    hideLabel: figma.boolean('Label', { true: false, false: true }),
     checked: figma.enum('Selected', { Yes: true }),
   },
   example: ({ label, hideLabel, checked }) => (
@@ -55,7 +55,7 @@ figma.connect(Radio, url, {
   variant: { State: 'Disabled' },
   props: {
     label: figma.string('Label'),
-    hideLabel: figma.boolean('Show Label', { true: false, false: true }),
+    hideLabel: figma.boolean('Label', { true: false, false: true }),
     checked: figma.enum('Selected', { Yes: true }),
   },
   example: ({ label, hideLabel, checked }) => (

--- a/components/radio/Radio.stories.tsx
+++ b/components/radio/Radio.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs', 'test', 'beta'],
+  tags: ['autodocs', 'test', 'stable'],
   argTypes: {
     id: {
       description:
@@ -337,7 +337,7 @@ export const InputOnly = {
  * No specific Figma design for RTL, but this story ensures that the component can be used in RTL contexts without layout or functionality issues. The label and feedback text are provided in Arabic to reflect a common RTL language scenario.
  */
 export const RightToLeft: Story = {
-  tags: ['test', 'beta'],
+  tags: ['test', 'stable'],
   parameters: {
     // The render function contains a dir="rtl" wrapper that isn't representative of component usage — suppress the code block in docs.
     docs: { source: { code: null } },


### PR DESCRIPTION
## Description

This branch makes two small follow-up fixes to the `Radio` and `CloseButton` component surfaces.

It promotes the `Radio` and `CloseButton` Storybook stories from `beta` to `stable` so their metadata matches the current component maturity, including the `RightToLeft` Radio story.

It also fixes the Radio Code Connect mapping so the `hideLabel` prop is derived from the correct Figma boolean prop name (`Label` instead of `Show Label`). That keeps the Figma-to-code mapping aligned with the current component definition and prevents incorrect prop inversion when using Code Connect.

## Related Jira or GitHub Issue

N/A

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

No UI changes beyond Storybook metadata and Figma Code Connect wiring.

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

Accessibility notes:

- No interaction or visual accessibility behavior changes are introduced by this branch.
- The Radio Code Connect fix improves design-to-code accuracy by mapping the label visibility control to the correct Figma prop.
