### PR TITLE
docs(PR): Add Code Connect requirement to component PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/component.md
@@ -15,6 +15,7 @@
 ### File structure and exports
 
 - [ ] All 5 required files present: `ComponentName.tsx`, `component-name.css`, `ComponentName.test.tsx`, `ComponentName.stories.tsx`, `index.tsx`
+- [ ] `ComponentName.figma.tsx` Code Connect file created and published
 - [ ] Named and type exports added to `components/index.tsx`
 - [ ] Component stylesheet imported in `components/index.css`
 


### PR DESCRIPTION
## Description

Updates the component PR template checklist to include Code Connect (`ComponentName.figma.tsx`) as a required file for all new components.

**What Changed**

Added an explicit checklist item under "File structure and exports" to ensure Code Connect mapping files are created and published alongside component implementations.

**Why**

Code Connect is now a standard requirement for component production readiness. This template update ensures reviewers and contributors catch missing Figma mappings during the PR process rather than post-merge.

## Related Jira or GitHub Issue

N/A

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

N/A

## Checklist

N/A

## Additional Notes

N/A