### PR TITLE
docs(Commits): Apply sentence-case requirement for scope

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,7 +109,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for branch, PR, review, and release proce
 
 - Commits must follow [Conventional Commits](https://www.conventionalcommits.org/).
 - Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`.
-- Subject must use sentence-case.
+- Scope and subject must use sentence-case: `feat(Button): Add icon support`.
 
 ## Guardrails
 

--- a/.github/linters/.commitlintrc.ts
+++ b/.github/linters/.commitlintrc.ts
@@ -20,6 +20,7 @@ module.exports = {
         'style',
       ],
     ],
+    'scope-case': [2, 'always', 'sentence-case'],
     'subject-case': [2, 'always', 'sentence-case'],
   },
 };


### PR DESCRIPTION
## Description

Updates commit conventions documentation to clarify that commit scopes must use sentence-case (e.g., `feat(Button):`, not `feat(button):`).

**What Changed**

- Updated `copilot-instructions.md` to specify that both scope and subject must use sentence-case.
- Added example: `feat(Button): Add icon support`.

**Why**

- Aligns documentation with the commitlint enforcement rule (`'scope-case': [2, 'always', 'sentence-case']`) so contributors understand the requirement upfront.

## Related Jira or GitHub Issue

N/A

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

N/A

## Checklist

N/A

## Additional Notes

N/A