### PR TITLE
feat(Badge): Add new Badge component

### DIFF
--- a/components/badge/Badge.figma.tsx
+++ b/components/badge/Badge.figma.tsx
@@ -4,7 +4,7 @@ import { Badge } from './Badge';
 const url =
   'https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=7309-410';
 
-const variant = figma.enum('Type', {
+const variant = figma.enum('Variant', {
   Primary: 'primary',
   Secondary: 'secondary',
   Success: 'success',
@@ -30,9 +30,9 @@ figma.connect(Badge, url, {
   ),
 });
 
-// Default contrast, prefix icon
+// Default contrast, start icon
 figma.connect(Badge, url, {
-  variant: { Contrast: 'Default', Icon: 'Prefix' },
+  variant: { Contrast: 'Default', Icon: 'startIcon' },
   props: {
     variant: variant,
     pill: pill,
@@ -47,9 +47,9 @@ figma.connect(Badge, url, {
   ),
 });
 
-// Default contrast, suffix icon
+// Default contrast, end icon
 figma.connect(Badge, url, {
-  variant: { Contrast: 'Default', Icon: 'Suffix' },
+  variant: { Contrast: 'Default', Icon: 'endIcon' },
   props: {
     variant: variant,
     pill: pill,
@@ -76,9 +76,9 @@ figma.connect(Badge, url, {
   ),
 });
 
-// Subtle contrast, prefix icon
+// Subtle contrast, start icon
 figma.connect(Badge, url, {
-  variant: { Contrast: 'Subtle', Icon: 'Prefix' },
+  variant: { Contrast: 'Subtle', Icon: 'startIcon' },
   props: {
     variant: variant,
     pill: pill,
@@ -94,9 +94,9 @@ figma.connect(Badge, url, {
   ),
 });
 
-// Subtle contrast, suffix icon
+// Subtle contrast, end icon
 figma.connect(Badge, url, {
-  variant: { Contrast: 'Subtle', Icon: 'Suffix' },
+  variant: { Contrast: 'Subtle', Icon: 'endIcon' },
   props: {
     variant: variant,
     pill: pill,

--- a/components/badge/Badge.figma.tsx
+++ b/components/badge/Badge.figma.tsx
@@ -1,0 +1,113 @@
+import figma from '@figma/code-connect';
+import { Badge } from './Badge';
+
+const url =
+  'https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=7309-410';
+
+const variant = figma.enum('Type', {
+  Primary: 'primary',
+  Secondary: 'secondary',
+  Success: 'success',
+  Danger: 'danger',
+  Warning: 'warning',
+  Info: 'info',
+});
+
+const pill = figma.enum('Style', {
+  Pill: true,
+  Default: false,
+});
+
+// Default contrast, no icon
+figma.connect(Badge, url, {
+  variant: { Contrast: 'Default', Icon: 'None' },
+  props: {
+    variant: variant,
+    pill: pill,
+  },
+  example: ({ variant, pill }) => (
+    <Badge label="Label" variant={variant} pill={pill} />
+  ),
+});
+
+// Default contrast, prefix icon
+figma.connect(Badge, url, {
+  variant: { Contrast: 'Default', Icon: 'Prefix' },
+  props: {
+    variant: variant,
+    pill: pill,
+  },
+  example: ({ variant, pill }) => (
+    <Badge
+      label="Label"
+      variant={variant}
+      pill={pill}
+      startIcon={<i className="fa-solid fa-circle-check" aria-hidden="true" />}
+    />
+  ),
+});
+
+// Default contrast, suffix icon
+figma.connect(Badge, url, {
+  variant: { Contrast: 'Default', Icon: 'Suffix' },
+  props: {
+    variant: variant,
+    pill: pill,
+  },
+  example: ({ variant, pill }) => (
+    <Badge
+      label="Label"
+      variant={variant}
+      pill={pill}
+      endIcon={<i className="fa-solid fa-xmark" aria-hidden="true" />}
+    />
+  ),
+});
+
+// Subtle contrast, no icon
+figma.connect(Badge, url, {
+  variant: { Contrast: 'Subtle', Icon: 'None' },
+  props: {
+    variant: variant,
+    pill: pill,
+  },
+  example: ({ variant, pill }) => (
+    <Badge label="Label" variant={variant} subtle pill={pill} />
+  ),
+});
+
+// Subtle contrast, prefix icon
+figma.connect(Badge, url, {
+  variant: { Contrast: 'Subtle', Icon: 'Prefix' },
+  props: {
+    variant: variant,
+    pill: pill,
+  },
+  example: ({ variant, pill }) => (
+    <Badge
+      label="Label"
+      variant={variant}
+      subtle
+      pill={pill}
+      startIcon={<i className="fa-solid fa-circle-check" aria-hidden="true" />}
+    />
+  ),
+});
+
+// Subtle contrast, suffix icon
+figma.connect(Badge, url, {
+  variant: { Contrast: 'Subtle', Icon: 'Suffix' },
+  props: {
+    variant: variant,
+    pill: pill,
+  },
+  example: ({ variant, pill }) => (
+    <Badge
+      label="Label"
+      variant={variant}
+      subtle
+      pill={pill}
+      endIcon={<i className="fa-solid fa-xmark" aria-hidden="true" />}
+    />
+  ),
+});

--- a/components/badge/Badge.stories.tsx
+++ b/components/badge/Badge.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+import { Badge } from './Badge';
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs', 'test', 'stable'],
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description:
+        'Visible badge text. Must be a caller-supplied translated string.',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'success', 'danger', 'warning', 'info'],
+      description: 'Colour and semantic variant.',
+      table: {
+        type: {
+          summary: 'primary | secondary | success | danger | warning | info',
+        },
+        defaultValue: { summary: 'primary' },
+      },
+    },
+    subtle: {
+      control: { type: 'boolean' },
+      description:
+        'Renders the low-contrast style: light tinted background, dark text, and a visible border.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    pill: {
+      control: { type: 'boolean' },
+      description: 'Renders a fully rounded pill shape.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    startIcon: {
+      control: false,
+      description:
+        'Optional icon rendered before the label. Must be an `<i>` or `<svg>` element.',
+      table: {
+        type: { summary: 'ReactElement<"i" | "svg">' },
+      },
+    },
+    endIcon: {
+      control: false,
+      description:
+        'Optional icon rendered after the label. Must be an `<i>` or `<svg>` element.',
+      table: {
+        type: { summary: 'ReactElement<"i" | "svg">' },
+      },
+    },
+  },
+  args: {
+    label: 'Label',
+    variant: undefined,
+    subtle: false,
+    pill: false,
+  },
+  play: async ({ canvasElement }) => {
+    const badges = canvasElement.querySelectorAll('.mds-badge');
+    await expect(badges.length).toBeGreaterThan(0);
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const variants = [
+  'primary',
+  'secondary',
+  'success',
+  'danger',
+  'warning',
+  'info',
+] as const;
+
+const icon = <i className="fa-solid fa-circle-info" aria-hidden="true" />;
+
+const showcaseRowStyle = {
+  display: 'flex',
+  gap: 'var(--mds-spacing-xs)',
+  flexWrap: 'wrap',
+} as const;
+
+const showcaseParameters = {
+  controls: { disable: true },
+  docs: {
+    canvas: { sourceState: 'none' },
+  },
+} as const;
+
+export const Primary: Story = {};
+
+export const DefaultVariants: Story = {
+  parameters: showcaseParameters,
+  render: () => (
+    <div style={showcaseRowStyle}>
+      {variants.map((variant) => (
+        <Badge
+          key={variant}
+          label={variant[0].toUpperCase() + variant.slice(1)}
+          variant={variant}
+        />
+      ))}
+    </div>
+  ),
+};
+
+export const SubtleVariants: Story = {
+  parameters: showcaseParameters,
+  render: () => (
+    <div style={showcaseRowStyle}>
+      {variants.map((variant) => (
+        <Badge
+          key={variant}
+          label={variant[0].toUpperCase() + variant.slice(1)}
+          variant={variant}
+          subtle
+        />
+      ))}
+    </div>
+  ),
+};
+
+export const PillVariants: Story = {
+  parameters: showcaseParameters,
+  render: () => (
+    <div style={showcaseRowStyle}>
+      <Badge label="Default" variant="primary" />
+      <Badge label="Pill" variant="primary" pill />
+    </div>
+  ),
+};
+
+export const RightToLeft: Story = {
+  args: {
+    label: 'حالة',
+    startIcon: icon,
+  },
+  decorators: [
+    (Story) => (
+      <div dir="rtl">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['test'],
+};

--- a/components/badge/Badge.stories.tsx
+++ b/components/badge/Badge.stories.tsx
@@ -88,7 +88,11 @@ const variants = [
   'info',
 ] as const;
 
-const icon = <i className="fa-solid fa-circle-info" aria-hidden="true" />;
+const startIcon = <i className="fa-solid fa-circle-check" aria-hidden="true" />;
+const endIcon = <i className="fa-solid fa-xmark" aria-hidden="true" />;
+
+const getVariantLabel = (variant: (typeof variants)[number]) =>
+  variant[0].toUpperCase() + variant.slice(1);
 
 const showcaseRowStyle = {
   display: 'flex',
@@ -112,7 +116,7 @@ export const DefaultVariants: Story = {
       {variants.map((variant) => (
         <Badge
           key={variant}
-          label={variant[0].toUpperCase() + variant.slice(1)}
+          label={getVariantLabel(variant)}
           variant={variant}
         />
       ))}
@@ -127,11 +131,69 @@ export const SubtleVariants: Story = {
       {variants.map((variant) => (
         <Badge
           key={variant}
-          label={variant[0].toUpperCase() + variant.slice(1)}
+          label={getVariantLabel(variant)}
           variant={variant}
           subtle
         />
       ))}
+    </div>
+  ),
+};
+
+export const IconDefaultVariants: Story = {
+  parameters: showcaseParameters,
+  render: () => (
+    <div style={{ display: 'grid', gap: 'var(--mds-spacing-xs)' }}>
+      <div style={showcaseRowStyle}>
+        {variants.map((variant) => (
+          <Badge
+            key={`${variant}-prefix`}
+            label={getVariantLabel(variant)}
+            variant={variant}
+            startIcon={startIcon}
+          />
+        ))}
+      </div>
+      <div style={showcaseRowStyle}>
+        {variants.map((variant) => (
+          <Badge
+            key={`${variant}-suffix`}
+            label={getVariantLabel(variant)}
+            variant={variant}
+            endIcon={endIcon}
+          />
+        ))}
+      </div>
+    </div>
+  ),
+};
+
+export const IconSubtleVariants: Story = {
+  parameters: showcaseParameters,
+  render: () => (
+    <div style={{ display: 'grid', gap: 'var(--mds-spacing-xs)' }}>
+      <div style={showcaseRowStyle}>
+        {variants.map((variant) => (
+          <Badge
+            key={`${variant}-subtle-prefix`}
+            label={getVariantLabel(variant)}
+            variant={variant}
+            subtle
+            startIcon={startIcon}
+          />
+        ))}
+      </div>
+      <div style={showcaseRowStyle}>
+        {variants.map((variant) => (
+          <Badge
+            key={`${variant}-subtle-suffix`}
+            label={getVariantLabel(variant)}
+            variant={variant}
+            subtle
+            endIcon={endIcon}
+          />
+        ))}
+      </div>
     </div>
   ),
 };
@@ -149,7 +211,7 @@ export const PillVariants: Story = {
 export const RightToLeft: Story = {
   args: {
     label: 'حالة',
-    startIcon: icon,
+    startIcon: startIcon,
   },
   decorators: [
     (Story) => (
@@ -158,5 +220,5 @@ export const RightToLeft: Story = {
       </div>
     ),
   ],
-  tags: ['test'],
+  tags: ['test', 'stable'],
 };

--- a/components/badge/Badge.test.tsx
+++ b/components/badge/Badge.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Badge } from './Badge';
+
+describe('Badge: Unit Test', () => {
+  it('renders the label text', () => {
+    render(<Badge label="New" />);
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('applies mds-badge and badge base classes', () => {
+    render(<Badge label="Label" />);
+    const badge = screen.getByText('Label');
+    expect(badge).toHaveClass('mds-badge');
+    expect(badge).toHaveClass('badge');
+  });
+
+  it.each([
+    'primary',
+    'secondary',
+    'success',
+    'danger',
+    'warning',
+    'info',
+  ] as const)('applies variant class for variant=%s', (variant) => {
+    render(<Badge label="Label" variant={variant} />);
+    expect(screen.getByText('Label')).toHaveClass(`mds-badge--${variant}`);
+  });
+
+  it('defaults to primary variant when no variant is supplied', () => {
+    render(<Badge label="Label" />);
+    expect(screen.getByText('Label')).toHaveClass('mds-badge--primary');
+  });
+
+  it('falls back to primary when an invalid variant is passed', () => {
+    // @ts-expect-error — intentional invalid value to verify runtime fallback
+    render(<Badge label="Label" variant="invalid" />);
+    expect(screen.getByText('Label')).toHaveClass('mds-badge--primary');
+    expect(screen.getByText('Label')).not.toHaveClass('mds-badge--invalid');
+  });
+
+  it('warns in development when an invalid variant is passed', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // @ts-expect-error — intentional invalid value
+    render(<Badge label="Label" variant="invalid" />);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid variant "invalid"'),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('does not apply subtle class by default', () => {
+    render(<Badge label="Label" />);
+    expect(screen.getByText('Label')).not.toHaveClass('mds-badge--subtle');
+  });
+
+  it('applies subtle class when subtle=true', () => {
+    render(<Badge label="Label" subtle />);
+    expect(screen.getByText('Label')).toHaveClass('mds-badge--subtle');
+  });
+
+  it('does not apply pill class by default', () => {
+    render(<Badge label="Label" />);
+    expect(screen.getByText('Label')).not.toHaveClass('mds-badge--pill');
+  });
+
+  it('applies pill class when pill=true', () => {
+    render(<Badge label="Label" pill />);
+    expect(screen.getByText('Label')).toHaveClass('mds-badge--pill');
+  });
+
+  it('renders startIcon before the label', () => {
+    const icon = (
+      <i className="fa fa-star" data-testid="start-icon" aria-hidden="true" />
+    );
+    render(<Badge label="Label" startIcon={icon} />);
+    const badge = screen.getByText('Label');
+    const firstChild = badge.firstChild as HTMLElement;
+    expect(firstChild).not.toBeNull();
+    expect(firstChild.dataset?.testid).toBe('start-icon');
+  });
+
+  it('renders svg startIcon before the label', () => {
+    const icon = (
+      <svg
+        data-testid="start-icon-svg"
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+      />
+    );
+    render(<Badge label="Label" startIcon={icon} />);
+    const badge = screen.getByText('Label');
+    const firstChild = badge.firstChild as HTMLElement;
+    expect(firstChild).not.toBeNull();
+    expect(firstChild.dataset?.testid).toBe('start-icon-svg');
+  });
+
+  it('renders endIcon after the label', () => {
+    const icon = (
+      <i className="fa fa-star" data-testid="end-icon" aria-hidden="true" />
+    );
+    render(<Badge label="Label" endIcon={icon} />);
+    const badge = screen.getByText('Label');
+    const lastChild = badge.lastChild as HTMLElement;
+    expect(lastChild).not.toBeNull();
+    expect(lastChild.dataset?.testid).toBe('end-icon');
+  });
+
+  it('renders svg endIcon after the label', () => {
+    const icon = (
+      <svg data-testid="end-icon-svg" aria-hidden="true" viewBox="0 0 16 16" />
+    );
+    render(<Badge label="Label" endIcon={icon} />);
+    const badge = screen.getByText('Label');
+    const lastChild = badge.lastChild as HTMLElement;
+    expect(lastChild).not.toBeNull();
+    expect(lastChild.dataset?.testid).toBe('end-icon-svg');
+  });
+
+  it('renders only startIcon when both startIcon and endIcon are provided', () => {
+    const start = (
+      <i className="fa fa-star" data-testid="start-icon" aria-hidden="true" />
+    );
+    const end = (
+      <i className="fa fa-star" data-testid="end-icon" aria-hidden="true" />
+    );
+
+    render(<Badge label="Label" startIcon={start} endIcon={end} />);
+
+    expect(screen.getByTestId('start-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('end-icon')).not.toBeInTheDocument();
+  });
+
+  it('warns when both startIcon and endIcon are valid icons', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const start = (
+      <i className="fa fa-star" data-testid="start-icon" aria-hidden="true" />
+    );
+    const end = (
+      <i className="fa fa-star" data-testid="end-icon" aria-hidden="true" />
+    );
+
+    render(<Badge label="Label" startIcon={start} endIcon={end} />);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '`startIcon` and `endIcon` are mutually exclusive',
+      ),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('does not warn about icon conflict when only one icon resolves as valid', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const end = (
+      <i className="fa fa-star" data-testid="end-icon" aria-hidden="true" />
+    );
+
+    // @ts-expect-error — intentional invalid icon to verify resolved-only conflict warning
+    render(<Badge label="Label" startIcon={<div />} endIcon={end} />);
+
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        '`startIcon` and `endIcon` are mutually exclusive',
+      ),
+    );
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('startIcon'));
+    vi.restoreAllMocks();
+  });
+
+  it('ignores an invalid startIcon value and logs an error', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // @ts-expect-error — intentional invalid icon
+    render(<Badge label="Label" startIcon={<div />} />);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('startIcon'));
+    vi.restoreAllMocks();
+  });
+
+  it('ignores an invalid endIcon value and logs an error', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // @ts-expect-error — intentional invalid icon
+    render(<Badge label="Label" endIcon={<div />} />);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('endIcon'));
+    expect(screen.queryByTestId('end-icon')).not.toBeInTheDocument();
+    vi.restoreAllMocks();
+  });
+
+  it('forwards extra props to the span element', () => {
+    render(<Badge label="Label" data-testid="my-badge" />);
+    expect(screen.getByTestId('my-badge')).toBeInTheDocument();
+  });
+
+  it('appends consumer className after the mds classes', () => {
+    render(<Badge label="Label" className="custom-class" />);
+    const span = screen.getByText('Label');
+    const classes = span.getAttribute('class') ?? '';
+    expect(classes.indexOf('mds-badge')).toBeLessThan(
+      classes.indexOf('custom-class'),
+    );
+  });
+
+  it('renders a span element as the host', () => {
+    render(<Badge label="Label" />);
+    expect(screen.getByText('Label').tagName).toBe('SPAN');
+  });
+});

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -1,0 +1,99 @@
+import type { HTMLAttributes, ReactElement } from 'react';
+import { isValidElement } from 'react';
+import './badge.css';
+
+type BadgeVariant =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info';
+
+type IconElement = ReactElement<'i' | 'svg'>;
+
+// Runtime guard — icon props must be <i> or <svg> elements
+const isIconElement = (el: unknown, propName: string): el is IconElement => {
+  const valid = isValidElement(el) && (el.type === 'i' || el.type === 'svg');
+  if (!valid && el != null && import.meta.env.DEV) {
+    console.error(`Badge: \`${propName}\` must be an <i> or <svg> element.`);
+  }
+  return valid;
+};
+
+const allowedVariants: BadgeVariant[] = [
+  'primary',
+  'secondary',
+  'success',
+  'danger',
+  'warning',
+  'info',
+];
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  /** Visible badge text. Must be a caller-supplied translated string. */
+  label: string;
+  /** Colour/semantic variant. Defaults to `primary`. */
+  variant?: BadgeVariant;
+  /** When true, renders the low-contrast (subtle) style with a light background and border. */
+  subtle?: boolean;
+  /** When true, renders fully rounded pill shape instead of the default slight rounding. */
+  pill?: boolean;
+  /** Optional icon rendered before the label. Must be an `<i>` or `<svg>` element. Mutually exclusive with `endIcon`. */
+  startIcon?: IconElement;
+  /** Optional icon rendered after the label. Must be an `<i>` or `<svg>` element. Mutually exclusive with `startIcon`. */
+  endIcon?: IconElement;
+}
+
+export const Badge = ({
+  label,
+  variant,
+  subtle = false,
+  pill = false,
+  startIcon,
+  endIcon,
+  className,
+  ...props
+}: BadgeProps) => {
+  const resolvedVariant =
+    variant && allowedVariants.includes(variant as BadgeVariant)
+      ? variant
+      : 'primary';
+
+  const resolvedStartIcon = isIconElement(startIcon, 'startIcon')
+    ? startIcon
+    : null;
+  let resolvedEndIcon = isIconElement(endIcon, 'endIcon') ? endIcon : null;
+
+  if (import.meta.env.DEV) {
+    if (variant && !allowedVariants.includes(variant as BadgeVariant)) {
+      console.warn(
+        `[MDS Badge] Invalid variant "${variant}". Falling back to "primary". Allowed: ${allowedVariants.join(', ')}`,
+      );
+    }
+    if (resolvedStartIcon && resolvedEndIcon) {
+      console.warn(
+        '[MDS Badge] `startIcon` and `endIcon` are mutually exclusive. Rendering `startIcon` only.',
+      );
+    }
+  }
+
+  // Only one icon can be rendered at a time; startIcon takes precedence when both are provided.
+  if (resolvedStartIcon && resolvedEndIcon) {
+    resolvedEndIcon = null;
+  }
+
+  const classes = ['mds-badge', 'badge', `mds-badge--${resolvedVariant}`];
+  if (resolvedStartIcon || resolvedEndIcon) classes.push('mds-badge--has-icon');
+  if (subtle) classes.push('mds-badge--subtle');
+  if (pill) classes.push('mds-badge--pill');
+  if (className) classes.push(className);
+
+  return (
+    <span className={classes.join(' ')} {...props}>
+      {resolvedStartIcon}
+      {label}
+      {resolvedEndIcon}
+    </span>
+  );
+};

--- a/components/badge/badge.css
+++ b/components/badge/badge.css
@@ -1,0 +1,115 @@
+.mds-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  padding: var(--mds-spacing-xxs) var(--mds-spacing-xs);
+  border-radius: var(--mds-border-radius-sm);
+
+  font-family: var(--mds-font-family-base);
+  font-weight: var(--mds-font-weight-medium);
+  font-size: var(--mds-font-size-paragraph-small);
+  line-height: var(--mds-line-height-paragraph-xs);
+  letter-spacing: var(--mds-letter-spacing-default);
+  white-space: nowrap;
+  vertical-align: baseline;
+}
+
+.mds-badge--has-icon {
+  gap: var(--mds-spacing-xxs);
+}
+
+/* Normalize icon dimensions to match the badge icon token across <i> and <svg> usage. */
+.mds-badge > i,
+.mds-badge > svg {
+  width: var(--mds-icons-xxs);
+  height: var(--mds-icons-xxs);
+  font-size: var(--mds-icons-xxs);
+  flex-shrink: 0;
+}
+
+/* Pill shape overrides the default rounded corners */
+.mds-badge--pill {
+  border-radius: var(--mds-border-radius-pill);
+}
+
+/*
+ * Per-variant colour rules.
+ * Default contrast: solid coloured background with inverse text.
+ * Subtle contrast (.mds-badge--subtle): light tinted background, dark feedback text, visible border.
+ */
+
+.mds-badge--subtle {
+  border: var(--mds-stroke-weight-sm) solid transparent;
+}
+
+/* --- Primary --- */
+.mds-badge--primary {
+  background-color: var(--mds-bg-feedback-primary-default);
+  color: var(--mds-text-inverse);
+}
+
+.mds-badge--primary.mds-badge--subtle {
+  background-color: var(--mds-bg-feedback-primary-subtle);
+  color: var(--mds-text-feedback-primary);
+  border-color: var(--mds-border-feedback-primary);
+}
+
+/* --- Secondary --- */
+.mds-badge--secondary {
+  background-color: var(--mds-bg-feedback-secondary-default);
+  color: var(--mds-text-feedback-secondary);
+}
+
+.mds-badge--secondary.mds-badge--subtle {
+  background-color: var(--mds-bg-feedback-secondary-subtle);
+  color: var(--mds-text-feedback-secondary);
+  border-color: var(--mds-border-feedback-secondary);
+}
+
+/* --- Success --- */
+.mds-badge--success {
+  background-color: var(--mds-bg-feedback-success-default);
+  color: var(--mds-text-inverse);
+}
+
+.mds-badge--success.mds-badge--subtle {
+  background-color: var(--mds-bg-feedback-success-subtle);
+  color: var(--mds-text-feedback-success);
+  border-color: var(--mds-border-feedback-success);
+}
+
+/* --- Danger --- */
+.mds-badge--danger {
+  background-color: var(--mds-bg-feedback-danger-default);
+  color: var(--mds-text-inverse);
+}
+
+.mds-badge--danger.mds-badge--subtle {
+  background-color: var(--mds-bg-feedback-danger-subtle);
+  color: var(--mds-text-feedback-danger);
+  border-color: var(--mds-border-feedback-danger);
+}
+
+/* --- Warning --- */
+.mds-badge--warning {
+  background-color: var(--mds-bg-feedback-warning-default);
+  color: var(--mds-text-feedback-warning);
+}
+
+.mds-badge--warning.mds-badge--subtle {
+  background-color: var(--mds-bg-feedback-warning-subtle);
+  color: var(--mds-text-feedback-warning);
+  border-color: var(--mds-border-feedback-warning);
+}
+
+/* --- Info --- */
+.mds-badge--info {
+  background-color: var(--mds-bg-feedback-info-default);
+  color: var(--mds-text-inverse);
+}
+
+.mds-badge--info.mds-badge--subtle {
+  background-color: var(--mds-bg-feedback-info-subtle);
+  color: var(--mds-text-feedback-info);
+  border-color: var(--mds-border-feedback-info);
+}

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -1,0 +1,1 @@
+export * from './Badge';

--- a/components/index.css
+++ b/components/index.css
@@ -1,4 +1,5 @@
 @import './activity-icon/activity-icon.css';
+@import './badge/badge.css';
 @import './button/button.css';
 @import './checkbox/checkbox.css';
 @import './close-button/close-button.css';

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -1,6 +1,9 @@
 export { ActivityIcon } from './activity-icon';
 export type { ActivityIconProps } from './activity-icon';
 
+export { Badge } from './badge';
+export type { BadgeProps } from './badge';
+
 export { Button } from './button';
 export type { ButtonProps } from './button';
 


### PR DESCRIPTION
## Description

Introduces the new Badge component with semantic feedback variants and optional icon support, aligned to Moodle token usage and cross-system naming.

The component provides:

- Variant support for primary, secondary, success, danger, warning, and info.
- Two visual styles: default contrast and subtle contrast.
- Optional pill shape.
- Optional start or end icon rendering, with a single-icon policy when both are passed.
- Runtime validation safeguards in development:
  - Invalid variant values fall back to primary with a warning.
  - Invalid icon elements (non-i/non-svg) are ignored with an error log.
  - If both start and end icons are valid, start icon takes precedence with a warning.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-492

## Screenshots/Previews

<img width="1017" height="826" alt="Screenshot 2026-05-22 at 2 40 33 pm" src="https://github.com/user-attachments/assets/e96db97a-4774-472b-8fcc-024475cfc58d" />

## Author checklist

### File structure and exports

- [x] All 5 required files present: `ComponentName.tsx`, `component-name.css`, `ComponentName.test.tsx`, `ComponentName.stories.tsx`, `index.tsx`
- [x] `ComponentName.figma.tsx` Code Connect file created and published
- [x] Named and type exports added to `components/index.tsx`
- [x] Component stylesheet imported in `components/index.css`

### TypeScript and props

- [x] Props interface extends the correct React HTML element interface (e.g. `ButtonHTMLAttributes<HTMLButtonElement>`)
- [x] JSDoc comment on each prop
- [x] Constrained props use `allowedValues` runtime validation with a graceful fallback to a documented default
- [x] `...props` spread last on the host element

### Internationalisation

- [x] All user-facing strings accepted as props — no hardcoded text in JSX
- [x] CSS uses logical properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`) for any directional layout
- [x] RTL story added if the component has directional layout

### CSS and tokens

- [x] All CSS values use `var(--mds-*)` tokens — no hardcoded colours, spacing, or typography

### Tests and stories

- [x] Unit tests cover: `mds-*` class on root, correct classes per variant/size, invalid prop fallback, prop forwarding, disabled state, and label rendering
- [x] Storybook stories cover all documented variants, sizes, and states
- [x] Accessibility tested — Axe WCAG AA scan runs automatically via CI on all stories tagged `test`

### Breaking changes

- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump

### AI context

- [x] Instruction files updated if this component introduces new patterns or anti-patterns

## Cross-system parity

- [x] Component name, prop names, and variant names are consistent across code, Storybook, Figma, and Zeroheight

## Additional Notes

<!-- Add any other context or information reviewers should know -->
