### PR TITLE
docs(CloseButton): Improve stories listing in Storybook

### DIFF
--- a/components/close-button/CloseButton.stories.tsx
+++ b/components/close-button/CloseButton.stories.tsx
@@ -46,7 +46,7 @@ const meta = {
   },
   args: {
     'aria-label': 'Close',
-    size: 'md',
+    size: undefined,
     disabled: false,
   },
   play: async ({ args, canvas, userEvent }) => {
@@ -63,17 +63,85 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const showcaseParameters = {
+  controls: { disable: true },
+  docs: {
+    canvas: { sourceState: 'none' as const },
+  },
+};
+
+const showcaseInlineStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--mds-spacing-sm)',
+};
+
 export const Default = {} satisfies Story;
 
-export const Small = {
-  args: {
-    size: 'sm',
+export const Sizes = {
+  parameters: showcaseParameters,
+  render: (args) => (
+    <div style={showcaseInlineStyle}>
+      <CloseButton
+        {...args}
+        size="sm"
+        aria-label={`${args['aria-label']} small`}
+      />
+      <CloseButton
+        {...args}
+        size="md"
+        aria-label={`${args['aria-label']} medium`}
+      />
+      <CloseButton
+        {...args}
+        size="lg"
+        aria-label={`${args['aria-label']} large`}
+      />
+    </div>
+  ),
+  play: async ({ args, canvas }) => {
+    const smallButton = canvas.getByRole('button', {
+      name: `${args['aria-label']} small`,
+    });
+    const mediumButton = canvas.getByRole('button', {
+      name: `${args['aria-label']} medium`,
+    });
+    const largeButton = canvas.getByRole('button', {
+      name: `${args['aria-label']} large`,
+    });
+
+    await expect(smallButton).toBeVisible();
+    await expect(mediumButton).toBeVisible();
+    await expect(largeButton).toBeVisible();
   },
 } satisfies Story;
 
-export const Large = {
-  args: {
-    size: 'lg',
+export const Disabled = {
+  parameters: showcaseParameters,
+  render: (args) => (
+    <div style={showcaseInlineStyle}>
+      <CloseButton
+        {...args}
+        disabled={false}
+        aria-label={`${args['aria-label']} default`}
+      />
+      <CloseButton
+        {...args}
+        disabled
+        aria-label={`${args['aria-label']} disabled`}
+      />
+    </div>
+  ),
+  play: async ({ args, canvas }) => {
+    const defaultButton = canvas.getByRole('button', {
+      name: `${args['aria-label']} default`,
+    });
+    const disabledButton = canvas.getByRole('button', {
+      name: `${args['aria-label']} disabled`,
+    });
+
+    await expect(defaultButton).toBeEnabled();
+    await expect(disabledButton).toBeDisabled();
   },
 } satisfies Story;
 
@@ -94,17 +162,5 @@ export const Focus = {
     await userEvent.click(document.body);
     await userEvent.tab();
     await expect(button).toHaveFocus();
-  },
-} satisfies Story;
-
-export const Disabled = {
-  args: {
-    disabled: true,
-  },
-  play: async ({ args, canvas }) => {
-    const button = canvas.getByRole('button', {
-      name: args['aria-label'] as string,
-    });
-    await expect(button).toBeDisabled();
   },
 } satisfies Story;


### PR DESCRIPTION
## Description

- Improves the CloseButton Storybook experience by replacing single-state stories with clearer side-by-side showcases and adding story-level interaction assertions that match the new layouts.
- Updated default args for size from `md` to `undefined` to let stories explicitly control size where needed. Showing a clearer default state of the code.

## Related Jira or GitHub Issue

N/A

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Screenshots/Previews
- Size is now defaulted to "choose an option..."
<img width="1062" height="800" alt="Screenshot 2026-05-22 at 9 33 40 am" src="https://github.com/user-attachments/assets/4d312754-2e94-4b72-b8d6-5c21167e2250" />
- Stories to be showcases
<img width="1041" height="721" alt="Screenshot 2026-05-22 at 9 33 27 am" src="https://github.com/user-attachments/assets/af3a5afa-34d5-4f9f-87ed-cecc2f3214f7" />

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

N/A
