### PR TITLE
docs(ActivityIcon)!: Improve stories listing in Storybook

### DIFF
--- a/components/activity-icon/ActivityIcon.figma.tsx
+++ b/components/activity-icon/ActivityIcon.figma.tsx
@@ -11,7 +11,7 @@ const size = figma.enum('Size', {
   XL: 'xl',
 });
 
-const variant = figma.enum('Container', {
+const container = figma.enum('Container', {
   None: 'none',
   Default: 'default',
   Large: 'large',
@@ -22,13 +22,13 @@ figma.connect(ActivityIcon, url, {
   variant: { Category: 'Collaboration' },
   props: {
     size: size,
-    variant: variant,
+    container: container,
   },
-  example: ({ size, variant }) => (
+  example: ({ size, container }) => (
     <ActivityIcon
       icon="database"
       size={size}
-      variant={variant}
+      container={container}
       alt="Collaboration activity"
     />
   ),
@@ -39,13 +39,13 @@ figma.connect(ActivityIcon, url, {
   variant: { Category: 'Communication' },
   props: {
     size: size,
-    variant: variant,
+    container: container,
   },
-  example: ({ size, variant }) => (
+  example: ({ size, container }) => (
     <ActivityIcon
       icon="chat"
       size={size}
-      variant={variant}
+      container={container}
       alt="Communication activity"
     />
   ),
@@ -56,13 +56,13 @@ figma.connect(ActivityIcon, url, {
   variant: { Category: 'Assessment' },
   props: {
     size: size,
-    variant: variant,
+    container: container,
   },
-  example: ({ size, variant }) => (
+  example: ({ size, container }) => (
     <ActivityIcon
       icon="assignment"
       size={size}
-      variant={variant}
+      container={container}
       alt="Assessment activity"
     />
   ),
@@ -73,13 +73,13 @@ figma.connect(ActivityIcon, url, {
   variant: { Category: 'Interactive' },
   props: {
     size: size,
-    variant: variant,
+    container: container,
   },
-  example: ({ size, variant }) => (
+  example: ({ size, container }) => (
     <ActivityIcon
       icon="ims-package"
       size={size}
-      variant={variant}
+      container={container}
       alt="Interactive activity"
     />
   ),
@@ -90,10 +90,15 @@ figma.connect(ActivityIcon, url, {
   variant: { Category: 'Resource' },
   props: {
     size: size,
-    variant: variant,
+    container: container,
   },
-  example: ({ size, variant }) => (
-    <ActivityIcon icon="book" size={size} variant={variant} alt="Resource" />
+  example: ({ size, container }) => (
+    <ActivityIcon
+      icon="book"
+      size={size}
+      container={container}
+      alt="Resource"
+    />
   ),
 });
 
@@ -102,13 +107,13 @@ figma.connect(ActivityIcon, url, {
   variant: { Category: 'Other' },
   props: {
     size: size,
-    variant: variant,
+    container: container,
   },
-  example: ({ size, variant }) => (
+  example: ({ size, container }) => (
     <ActivityIcon
       icon="subsection"
       size={size}
-      variant={variant}
+      container={container}
       alt="Activity"
     />
   ),

--- a/components/activity-icon/ActivityIcon.stories.tsx
+++ b/components/activity-icon/ActivityIcon.stories.tsx
@@ -34,11 +34,10 @@ const meta = {
         defaultValue: { summary: 'md' },
       },
     },
-    variant: {
+    container: {
       control: { type: 'select' },
       options: ['none', 'default', 'large'],
-      description:
-        'Background/size variant matching Figma activity icon treatments.',
+      description: 'Container treatment matching Figma activity icon styles.',
       table: {
         type: { summary: 'none | default | large' },
         defaultValue: { summary: 'default' },
@@ -56,8 +55,8 @@ const meta = {
   },
   args: {
     icon: 'assignment',
-    size: 'md',
-    variant: 'default',
+    size: undefined,
+    container: undefined,
     alt: '',
   },
 } satisfies Meta<typeof ActivityIcon>;
@@ -66,111 +65,165 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const VariantDefault: Story = {
-  args: {
-    variant: 'default',
-    icon: 'assignment',
+const showcaseParameters = {
+  controls: { disable: true },
+  docs: {
+    canvas: { sourceState: 'none' as const },
   },
 };
 
-export const VariantNone: Story = {
-  args: {
-    variant: 'none',
-    icon: 'assignment',
-  },
+const showcaseStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--mds-spacing-md)',
 };
 
-export const VariantLarge: Story = {
-  args: {
-    variant: 'large',
-    icon: 'assignment',
-  },
-};
+export const Default: Story = {};
 
-export const WithAltText: Story = {
-  args: {
-    variant: 'default',
-    icon: 'assignment',
-    alt: 'Assignment activity icon',
-  },
+export const Containers: Story = {
+  parameters: showcaseParameters,
+  render: (args) => (
+    <div style={showcaseStyles}>
+      <ActivityIcon
+        {...args}
+        container="none"
+        icon="assignment"
+        alt="None container"
+      />
+      <ActivityIcon
+        {...args}
+        container="default"
+        icon="assignment"
+        alt="Default container"
+      />
+      <ActivityIcon
+        {...args}
+        container="large"
+        icon="assignment"
+        alt="Large container"
+      />
+    </div>
+  ),
   play: async ({ canvas }) => {
     await expect(
-      canvas.getByRole('img', { name: 'Assignment activity icon' }),
+      canvas.getByRole('img', { name: 'None container' }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Default container' }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Large container' }),
     ).toBeVisible();
   },
 };
 
-export const SizeSmall: Story = {
-  args: {
-    size: 'sm',
-    variant: 'default',
-    icon: 'assignment',
+export const Sizes: Story = {
+  parameters: showcaseParameters,
+  render: (args) => (
+    <div style={showcaseStyles}>
+      <ActivityIcon
+        {...args}
+        size="sm"
+        container="default"
+        icon="assignment"
+        alt="Small size"
+      />
+      <ActivityIcon
+        {...args}
+        size="md"
+        container="default"
+        icon="assignment"
+        alt="Medium size"
+      />
+      <ActivityIcon
+        {...args}
+        size="lg"
+        container="default"
+        icon="assignment"
+        alt="Large size"
+      />
+      <ActivityIcon
+        {...args}
+        size="xl"
+        container="default"
+        icon="assignment"
+        alt="Extra large size"
+      />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('img', { name: 'Small size' })).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Medium size' }),
+    ).toBeVisible();
+    await expect(canvas.getByRole('img', { name: 'Large size' })).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Extra large size' }),
+    ).toBeVisible();
   },
 };
 
-export const SizeMedium: Story = {
-  args: {
-    size: 'md',
-    variant: 'default',
-    icon: 'assignment',
-  },
-};
-
-export const SizeLarge: Story = {
-  args: {
-    size: 'lg',
-    variant: 'default',
-    icon: 'assignment',
-  },
-};
-
-export const SizeExtraLarge: Story = {
-  args: {
-    size: 'xl',
-    variant: 'default',
-    icon: 'assignment',
-  },
-};
-
-export const CategoryCollaboration: Story = {
-  args: {
-    variant: 'default',
-    icon: 'forum',
-  },
-};
-
-export const CategoryAssessment: Story = {
-  args: {
-    variant: 'default',
-    icon: 'assignment',
-  },
-};
-
-export const CategoryCommunication: Story = {
-  args: {
-    variant: 'default',
-    icon: 'chat',
-  },
-};
-
-export const CategoryInteractive: Story = {
-  args: {
-    variant: 'default',
-    icon: 'lesson',
-  },
-};
-
-export const CategoryOther: Story = {
-  args: {
-    variant: 'default',
-    icon: 'h5p',
-  },
-};
-
-export const CategoryResource: Story = {
-  args: {
-    variant: 'default',
-    icon: 'file-pdf',
+export const Categories: Story = {
+  parameters: showcaseParameters,
+  render: (args) => (
+    <div style={{ ...showcaseStyles, flexWrap: 'wrap' }}>
+      <ActivityIcon
+        {...args}
+        container="default"
+        icon="forum"
+        alt="Collaboration category"
+      />
+      <ActivityIcon
+        {...args}
+        container="default"
+        icon="assignment"
+        alt="Assessment category"
+      />
+      <ActivityIcon
+        {...args}
+        container="default"
+        icon="chat"
+        alt="Communication category"
+      />
+      <ActivityIcon
+        {...args}
+        container="default"
+        icon="lesson"
+        alt="Interactive category"
+      />
+      <ActivityIcon
+        {...args}
+        container="default"
+        icon="h5p"
+        alt="Other category"
+      />
+      <ActivityIcon
+        {...args}
+        container="default"
+        icon="file-pdf"
+        alt="Resource category"
+      />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole('img', { name: 'Collaboration category' }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Assessment category' }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Communication category' }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Interactive category' }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Other category' }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole('img', { name: 'Resource category' }),
+    ).toBeVisible();
   },
 };
 
@@ -245,7 +298,7 @@ export const AllIcons: Story = {
                 >
                   <ActivityIcon
                     icon={name}
-                    variant="default"
+                    container="default"
                     size="md"
                     alt=""
                   />

--- a/components/activity-icon/ActivityIcon.test.tsx
+++ b/components/activity-icon/ActivityIcon.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { ActivityIconSize, ActivityIconVariant } from './ActivityIcon';
+import type { ActivityIconContainer, ActivityIconSize } from './ActivityIcon';
 import { ActivityIcon } from './ActivityIcon';
 
 describe('ActivityIcon: Unit Test', () => {
@@ -20,7 +20,7 @@ describe('ActivityIcon: Unit Test', () => {
     });
   });
 
-  it('applies default variant by default', () => {
+  it('applies default container by default', () => {
     render(<ActivityIcon data-testid="icon" icon="assignment" />);
     expect(
       screen
@@ -70,18 +70,18 @@ describe('ActivityIcon: Unit Test', () => {
     ).toBe(true);
   });
 
-  it('applies none background variant', () => {
+  it('applies none container', () => {
     render(
-      <ActivityIcon data-testid="icon" icon="assignment" variant="none" />,
+      <ActivityIcon data-testid="icon" icon="assignment" container="none" />,
     );
     expect(
       screen.getByTestId('icon').classList.contains('mds-activity-icon--none'),
     ).toBe(true);
   });
 
-  it('applies default background variant', () => {
+  it('applies default container', () => {
     render(
-      <ActivityIcon data-testid="icon" icon="assignment" variant="default" />,
+      <ActivityIcon data-testid="icon" icon="assignment" container="default" />,
     );
     expect(
       screen
@@ -90,9 +90,9 @@ describe('ActivityIcon: Unit Test', () => {
     ).toBe(true);
   });
 
-  it('applies large background variant', () => {
+  it('applies large container', () => {
     render(
-      <ActivityIcon data-testid="icon" icon="assignment" variant="large" />,
+      <ActivityIcon data-testid="icon" icon="assignment" container="large" />,
     );
     expect(
       screen.getByTestId('icon').classList.contains('mds-activity-icon--large'),
@@ -132,14 +132,14 @@ describe('ActivityIcon: Unit Test', () => {
     error.mockRestore();
   });
 
-  it('falls back to default for an invalid variant', () => {
+  it('falls back to default for an invalid container', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(
       <ActivityIcon
         data-testid="icon"
         icon="assignment"
-        variant={'invalid' as unknown as ActivityIconVariant}
+        container={'invalid' as unknown as ActivityIconContainer}
       />,
     );
 
@@ -151,18 +151,18 @@ describe('ActivityIcon: Unit Test', () => {
     vi.restoreAllMocks();
   });
 
-  it('warns in development when an invalid variant is passed', () => {
+  it('warns in development when an invalid container is passed', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(
       <ActivityIcon
         icon="assignment"
-        variant={'invalid' as unknown as ActivityIconVariant}
+        container={'invalid' as unknown as ActivityIconContainer}
       />,
     );
 
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('[MDS ActivityIcon] Invalid variant "invalid"'),
+      expect.stringContaining('[MDS ActivityIcon] Invalid container "invalid"'),
     );
     warn.mockRestore();
   });

--- a/components/activity-icon/ActivityIcon.tsx
+++ b/components/activity-icon/ActivityIcon.tsx
@@ -25,8 +25,8 @@ function loadIconSrc(fileName: string): Promise<string> {
   return loader().then((mod) => mod.default);
 }
 
-export type ActivityIconVariant = 'none' | 'default' | 'large';
-const allowedVariants: ActivityIconVariant[] = ['none', 'default', 'large'];
+export type ActivityIconContainer = 'none' | 'default' | 'large';
+const allowedContainers: ActivityIconContainer[] = ['none', 'default', 'large'];
 
 export type ActivityIconSize = 'sm' | 'md' | 'lg' | 'xl';
 const allowedSizes: ActivityIconSize[] = ['sm', 'md', 'lg', 'xl'];
@@ -44,7 +44,7 @@ export interface ActivityIconProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * Visual container style around the icon.
    */
-  variant?: ActivityIconVariant;
+  container?: ActivityIconContainer;
   /**
    * Icon size token.
    */
@@ -54,7 +54,7 @@ export interface ActivityIconProps extends HTMLAttributes<HTMLSpanElement> {
 export const ActivityIcon = ({
   icon,
   alt = '',
-  variant,
+  container,
   size,
   className,
   ...props
@@ -71,9 +71,13 @@ export const ActivityIcon = ({
     );
   }
 
-  if (import.meta.env.DEV && variant && !allowedVariants.includes(variant)) {
+  if (
+    import.meta.env.DEV &&
+    container &&
+    !allowedContainers.includes(container)
+  ) {
     console.warn(
-      `[MDS ActivityIcon] Invalid variant "${variant}". Falling back to "default". Allowed: ${allowedVariants.join(', ')}`,
+      `[MDS ActivityIcon] Invalid container "${container}". Falling back to "default". Allowed: ${allowedContainers.join(', ')}`,
     );
   }
 
@@ -86,8 +90,8 @@ export const ActivityIcon = ({
   const resolvedIcon: ActivityIconName = hasValidIcon
     ? (normalizedIcon as ActivityIconName)
     : iconLookupFallback;
-  const resolvedVariant =
-    variant && allowedVariants.includes(variant) ? variant : 'default';
+  const resolvedContainer =
+    container && allowedContainers.includes(container) ? container : 'default';
   const resolvedSize = size && allowedSizes.includes(size) ? size : 'md';
   const resolvedCategory = activityIconRegistry[resolvedIcon].category;
   const [iconSrc, setIconSrc] = useState<string | undefined>(undefined);
@@ -115,7 +119,7 @@ export const ActivityIcon = ({
 
   const classes = [
     'mds-activity-icon',
-    `mds-activity-icon--${resolvedVariant}`,
+    `mds-activity-icon--${resolvedContainer}`,
     `mds-activity-icon--size-${resolvedSize}`,
     `mds-activity-icon--category-${resolvedCategory}`,
   ];


### PR DESCRIPTION
## Description

- Improves ActivityIcon Storybook coverage and discoverability while aligning the component API with design language by renaming the public prop from `variant` to `container`
- Improves the ActivityIcon Storybook experience by replacing single-state stories with clearer side-by-side showcases and adding story-level interaction assertions that match the new layouts.
- Updated default args for size from `md` to `undefined` to let stories explicitly control size where needed. Showing a clearer default state of the code.


## Related Jira or GitHub Issue

N/A

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Screenshots/Previews
- Size is now defaulted to "choose an option..." and `variant` is renamed to `container`
<img width="1067" height="887" alt="Screenshot 2026-05-22 at 10 41 39 am" src="https://github.com/user-attachments/assets/76fd5671-2366-4f34-a1ba-f6f9ce5ba823" />

- Stories to be showcases
<img width="1046" height="1021" alt="Screenshot 2026-05-22 at 10 41 25 am" src="https://github.com/user-attachments/assets/0b07e0f0-005e-4c80-b1ce-dd6c05182ad3" />

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

**BREAKING CHANGE:** `variant` prop is now renamed to `container`
