### PR TITLE
fix(Tokens): Darken info default color for a11y

### DIFF
--- a/tokens/css/colors.css
+++ b/tokens/css/colors.css
@@ -20,7 +20,7 @@
   --mds-activity-icon-resource-icon: var(--mds-color-cyan-500);
   --mds-bg-feedback-danger-light: var(--mds-color-red-50);
   --mds-bg-feedback-danger-subtle: var(--mds-color-red-100);
-  --mds-bg-feedback-info-default: var(--mds-color-cyan-500);
+  --mds-bg-feedback-info-default: var(--mds-color-cyan-600);
   --mds-bg-feedback-info-light: var(--mds-color-cyan-50);
   --mds-bg-feedback-info-subtle: var(--mds-color-cyan-100);
   --mds-bg-feedback-primary-default: var(--mds-color-blue-500);

--- a/tokens/dtcg/token_colors_Light.json
+++ b/tokens/dtcg/token_colors_Light.json
@@ -90,7 +90,7 @@
       "info": {
         "default": {
           "$type": "color",
-          "$value": "{color.cyan.500}"
+          "$value": "{color.cyan.600}"
         },
         "light": {
           "$type": "color",

--- a/tokens/scss/_colors.scss
+++ b/tokens/scss/_colors.scss
@@ -18,7 +18,7 @@ $mds-activity-icon-resource-icon: #008196 !default;
 $mds-bg-feedback-danger-default: #ca3120 !default;
 $mds-bg-feedback-danger-light: #faeae9 !default;
 $mds-bg-feedback-danger-subtle: #f4d6d2 !default;
-$mds-bg-feedback-info-default: #008196 !default;
+$mds-bg-feedback-info-default: #006778 !default;
 $mds-bg-feedback-info-light: #e5f2f4 !default;
 $mds-bg-feedback-info-subtle: #cce6ea !default;
 $mds-bg-feedback-primary-default: #0f6cbf !default;


### PR DESCRIPTION

# Updated "**LMS 5.0 Design System**" from zeroheight

The token set "**LMS 5.0 Design System**" has been updated via a sync from zeroheight.

Tokens have been exported in the following formats: _**DTCG JSON**_

**Push initiated by:** Boris ([view token set on zeroheight](https://moodle.zeroheight.com/tokens/14094?token_set_source=figma_plugin))

_Review the changes to ensure the tokens have been updated accordingly_
