### PR TITLE
feat(Pagination): Introduce pagination component

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -12,3 +12,49 @@
   font-weight: 100 900;
   font-style: italic;
 }
+
+/* ---------------------------------------------------------------------------
+ * Pseudo-state class equivalents for storybook-addon-pseudo-states.
+ *
+ * The addon rewrites document stylesheets at runtime to add .pseudo-* class
+ * selectors alongside every :pseudo-state rule. In Vite dev mode the CSS is
+ * injected into the iframe after the addon's STORY_RENDERED rewrite pass, so
+ * the rewrite never lands on our component stylesheets. Adding the equivalents
+ * here (a static file loaded before stories render) is the correct fallback.
+ *
+ * Rules mirror the `:focus-visible` declarations in each component's CSS file.
+ * Note: do NOT combine real pseudo-states (e.g. :active) with .pseudo-* class
+ * names in this file — the addon will attempt to rewrite such rules, produce
+ * an empty selector, and throw a CSSStyleSheet insertRule error.
+ * --------------------------------------------------------------------------- */
+
+/* All components — default focus ring */
+.mds-btn.btn.pseudo-focus-visible,
+.mds-checkbox-input.pseudo-focus-visible,
+.mds-form-check-input.pseudo-focus-visible,
+.mds-pagination__button.pseudo-focus-visible:not(:disabled),
+.mds-pagination__page.pseudo-focus-visible:not(:disabled) {
+  outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
+  outline-offset: var(--mds-spacing-offset);
+  box-shadow: none;
+}
+
+/* Close button — different offset and opacity */
+.mds-close-button.btn-close.pseudo-focus-visible {
+  outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
+  outline-offset: var(--mds-spacing-none);
+  box-shadow: none;
+  opacity: 1;
+}
+
+/* Button danger — outline color override */
+.mds-btn.btn.btn-danger.pseudo-focus-visible,
+.mds-btn.btn.btn-outline-danger.pseudo-focus-visible {
+  outline-color: var(--mds-focus-danger);
+}
+
+/* Checkbox / radio invalid — outline color override */
+.mds-checkbox-input.is-invalid.pseudo-focus-visible,
+.mds-form-check-input.is-invalid.pseudo-focus-visible {
+  outline-color: var(--mds-border-feedback-danger);
+}

--- a/components/index.css
+++ b/components/index.css
@@ -3,4 +3,5 @@
 @import './button/button.css';
 @import './checkbox/checkbox.css';
 @import './close-button/close-button.css';
+@import './pagination/pagination.css';
 @import './radio/radio.css';

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -13,5 +13,8 @@ export type { CheckboxProps } from './checkbox';
 export { CloseButton } from './close-button';
 export type { CloseButtonProps } from './close-button';
 
+export { Pagination } from './pagination';
+export type { PaginationProps } from './pagination';
+
 export { Radio } from './radio';
 export type { RadioProps } from './radio';

--- a/components/pagination/Pagination.figma.tsx
+++ b/components/pagination/Pagination.figma.tsx
@@ -1,0 +1,61 @@
+import figma from '@figma/code-connect';
+import { Pagination } from './Pagination';
+
+// Use the Pagination component set node (not a docs frame instance) so Dev Mode
+// can apply this mapping consistently across all shown examples.
+const url =
+  'https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=8367-5141';
+
+// Full variant: pagination with page numbers.
+figma.connect(Pagination, url, {
+  variant: { 'Current page': 'Middle page', 'Total pages': '9 or more' },
+  example: () => (
+    <Pagination
+      totalPages={10}
+      currentPage={5}
+      ariaLabel="Pagination"
+      onPageChange={() => {}}
+    />
+  ),
+});
+
+// Grouped variant: previous and next controls only.
+// In the current Figma component set this is represented by Total pages=None.
+figma.connect(Pagination, url, {
+  variant: { 'Current page': 'Middle page', 'Total pages': 'None' },
+  example: () => (
+    <Pagination
+      totalPages={10}
+      currentPage={5}
+      variant="grouped"
+      ariaLabel="Pagination"
+      onPageChange={() => {}}
+    />
+  ),
+});
+
+// First page variant: previous button disabled.
+figma.connect(Pagination, url, {
+  variant: { 'Current page': 'First page', 'Total pages': '9 or more' },
+  example: () => (
+    <Pagination
+      totalPages={10}
+      currentPage={1}
+      ariaLabel="Pagination"
+      onPageChange={() => {}}
+    />
+  ),
+});
+
+// Last page variant: next button disabled.
+figma.connect(Pagination, url, {
+  variant: { 'Current page': 'Last page', 'Total pages': '9 or more' },
+  example: () => (
+    <Pagination
+      totalPages={10}
+      currentPage={10}
+      ariaLabel="Pagination"
+      onPageChange={() => {}}
+    />
+  ),
+});

--- a/components/pagination/Pagination.stories.tsx
+++ b/components/pagination/Pagination.stories.tsx
@@ -1,0 +1,611 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent } from 'storybook/test';
+import { Pagination } from './Pagination';
+
+const meta = {
+  title: 'Components/Pagination',
+  component: Pagination,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs', 'test', 'stable'],
+  argTypes: {
+    totalPages: {
+      control: { type: 'number', min: 1, max: 1000, step: 1 },
+      description: 'Total number of pages',
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+    currentPage: {
+      control: { type: 'number', min: 1, max: 1000, step: 1 },
+      description: 'Current page number (1-indexed)',
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+    onPageChange: {
+      description: 'Callback fired when the page changes',
+      table: {
+        type: { summary: '(page: number) => void' },
+      },
+    },
+    ariaLabel: {
+      control: { type: 'text' },
+      description: 'Accessible name for the pagination landmark.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: "'Pagination'" },
+      },
+    },
+    previousPageLabel: {
+      control: { type: 'text' },
+      description: 'Accessible label used for the previous-page button.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: "'Previous page'" },
+      },
+    },
+    nextPageLabel: {
+      control: { type: 'text' },
+      description: 'Accessible label used for the next-page button.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: "'Next page'" },
+      },
+    },
+    pageLabelFormatter: {
+      control: false,
+      description:
+        'Returns the accessible label for each numbered page button.',
+      table: {
+        type: { summary: '(page: number) => string' },
+        defaultValue: { summary: '(page) => `Page ${page}`' },
+      },
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['full', 'grouped'],
+      description:
+        "Controls which variant to render. `'full'` shows page numbers (default). `'grouped'` shows only previous and next controls. When `'full'`, the component automatically collapses to grouped appearance on very narrow viewports.",
+      table: {
+        type: { summary: 'full | grouped' },
+        defaultValue: { summary: "'full'" },
+      },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description:
+        'Disables all interactive elements, preventing focus, hover, and page-change events.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+  args: {
+    totalPages: 10,
+    currentPage: 1,
+    ariaLabel: 'Pagination',
+    onPageChange: () => {},
+    disabled: false,
+  },
+  play: async ({ canvas }) => {
+    // Basic accessibility checks
+    const nav = canvas.getByRole('navigation');
+    await expect(nav).toHaveAttribute('aria-label', 'Pagination');
+
+    const buttons = canvas.getAllByRole('button');
+    expect(buttons.length).toBeGreaterThan(0);
+  },
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const pseudoMatrixStates = [
+  { key: 'default', label: 'Default' },
+  { key: 'hover', label: 'Hover' },
+  { key: 'pressed', label: 'Pressed' },
+  { key: 'focus-visible', label: 'Focus' },
+  { key: 'disabled', label: 'Disabled' },
+] as const;
+
+const pseudoMatrixRows = [
+  {
+    key: 'selected-page',
+    label: 'Selected page button (full)',
+    target: 'selected',
+  },
+  {
+    key: 'grouped-controls',
+    label: 'Previous and next buttons (grouped)',
+    target: 'nav-controls',
+  },
+] as const;
+
+type PseudoMatrixStateKey = (typeof pseudoMatrixStates)[number]['key'];
+type PseudoMatrixRow = (typeof pseudoMatrixRows)[number];
+
+const pseudoMatrixContainerStyle = {
+  display: 'grid' as const,
+  gap: 'var(--mds-spacing-md)',
+  overflowX: 'auto' as const,
+};
+
+const pseudoMatrixGridStyle = {
+  display: 'grid' as const,
+  rowGap: 'var(--mds-spacing-sm)',
+  columnGap: 'var(--mds-spacing-lg)',
+  gridTemplateColumns: '20rem repeat(5, 16rem)',
+  alignItems: 'center' as const,
+};
+
+const pseudoMatrixLabelCellStyle = {
+  color: 'var(--mds-text-subtle)',
+  fontSize: 'var(--mds-font-size-paragraph-small)',
+  fontFamily: 'var(--mds-font-family-base)',
+  fontWeight: 'var(--mds-font-weight-medium)',
+};
+
+const pseudoMatrixStateCellStyle = {
+  minHeight: '4rem',
+  display: 'inline-flex' as const,
+  alignItems: 'center' as const,
+  justifyContent: 'flex-start' as const,
+};
+
+function renderPseudoStateCell(
+  row: PseudoMatrixRow,
+  state: PseudoMatrixStateKey,
+) {
+  const isSelectedRow = row.target === 'selected';
+  const isGroupedControlsRow = row.target === 'nav-controls';
+  const isDisabled = state === 'disabled';
+
+  // Keep selected-page cells compact so matrix columns do not collide visually.
+  const totalPages = isSelectedRow ? 3 : 5;
+
+  return (
+    <div
+      data-matrix-state={state}
+      data-matrix-row={row.key}
+      data-matrix-target={row.target}
+      style={pseudoMatrixStateCellStyle}
+    >
+      <Pagination
+        totalPages={totalPages}
+        currentPage={2}
+        disabled={isDisabled}
+        variant={isGroupedControlsRow ? 'grouped' : 'full'}
+        ariaLabel={`Pagination ${row.label} ${state}`}
+        style={{ flexWrap: 'nowrap' }}
+        onPageChange={() => {}}
+      />
+    </div>
+  );
+}
+
+function InteractiveDefaultPagination(
+  args: React.ComponentProps<typeof Pagination>,
+) {
+  // Local state keeps interaction tests deterministic.
+  const [localCurrentPage, setLocalCurrentPage] = useState(args.currentPage);
+
+  return (
+    <Pagination
+      {...args}
+      currentPage={localCurrentPage}
+      onPageChange={setLocalCurrentPage}
+    />
+  );
+}
+
+export const Default: Story = {
+  args: {
+    totalPages: 10,
+    currentPage: 1,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Interactive default story used as a testing harness to verify selected-page updates on user interaction.',
+      },
+      source: {
+        code: `<Pagination
+  currentPage={1}
+  onPageChange={() => {}}
+  totalPages={10}
+/>
+`,
+      },
+    },
+  },
+  render: (args) => (
+    // Remount when controls change so the local story state re-initializes.
+    <InteractiveDefaultPagination
+      key={`${args.totalPages}-${args.currentPage}-${args.variant ?? 'full'}-${String(args.disabled)}`}
+      {...args}
+    />
+  ),
+  play: async ({ canvas }) => {
+    const page4Btn = canvas.getByRole('button', { name: /page 4/i });
+    await userEvent.click(page4Btn);
+    // useArgs-driven updates are async in Storybook interaction runs.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const selectedPage4Btn = canvas.getByRole('button', { name: /page 4/i });
+    await expect(selectedPage4Btn).toHaveAttribute('aria-current', 'page');
+
+    const page1Btn = canvas.getByRole('button', { name: /^page 1$/i });
+    await expect(page1Btn).not.toHaveAttribute('aria-current');
+  },
+};
+
+export const Grouped: Story = {
+  name: 'Grouped variant',
+  args: {
+    totalPages: 10,
+    currentPage: 5,
+    variant: 'grouped',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Explicit `variant='grouped'` shows only previous and next controls without page numbers. Use this when the caller determines the viewport is too narrow for full pagination, or as an accessible simplified navigation option.",
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    // Grouped variant hides all page-number buttons.
+    const pageButtons = canvas.queryAllByRole('button').filter((btn) => {
+      const ariaLabel = btn.getAttribute('aria-label');
+      return ariaLabel && ariaLabel.startsWith('Page');
+    });
+    await expect(pageButtons.length).toBe(0);
+  },
+};
+
+export const CustomAccessibleLabels: Story = {
+  args: {
+    totalPages: 10,
+    currentPage: 4,
+    ariaLabel: 'Course results pagination',
+    previousPageLabel: 'Go to previous results page',
+    nextPageLabel: 'Go to next results page',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows how to override the default accessible labels for translated or context-specific pagination text. Use `pageLabelFormatter` when numbered page buttons also need custom wording.',
+      },
+      source: {
+        code: `<Pagination
+  totalPages={10}
+  currentPage={4}
+  onPageChange={() => {}}
+  ariaLabel="Course results pagination"
+  previousPageLabel="Go to previous results page"
+  nextPageLabel="Go to next results page"
+  pageLabelFormatter={(page) => \`Results page \${page}\`}
+/>
+`,
+      },
+    },
+  },
+  render: (args) => (
+    <Pagination
+      {...args}
+      pageLabelFormatter={(page) => `Results page ${page}`}
+    />
+  ),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole('navigation', { name: 'Course results pagination' }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Go to previous results page' }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Results page 4' }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const PseudoStateMatrix: Story = {
+  parameters: {
+    layout: 'padded',
+    controls: { disable: true },
+    docs: {
+      canvas: { sourceState: 'none' },
+      description: {
+        story:
+          'Simplified matrix of Figma-aligned interaction states (`Default`, `Hover`, `Pressed`, `Focus`, `Disabled`) using selected page, previous button, and next button controls. The selected-page disabled cell mirrors the page-link disabled visual values.',
+      },
+    },
+    pseudo: {
+      hover:
+        "[data-matrix-state='hover'][data-matrix-target='selected'] .mds-pagination__page[data-current='true'], [data-matrix-state='hover'][data-matrix-target='nav-controls'] .mds-pagination__button--prev",
+      active:
+        "[data-matrix-state='pressed'][data-matrix-target='selected'] .mds-pagination__page[data-current='true'], [data-matrix-state='pressed'][data-matrix-target='nav-controls'] .mds-pagination__button--prev",
+      focusVisible:
+        "[data-matrix-state='focus-visible'][data-matrix-target='selected'] .mds-pagination__page[data-current='true'], [data-matrix-state='focus-visible'][data-matrix-target='nav-controls'] .mds-pagination__button--prev",
+    },
+  },
+  render: () => (
+    <div style={pseudoMatrixContainerStyle}>
+      <div style={pseudoMatrixGridStyle}>
+        <span style={pseudoMatrixLabelCellStyle}>Control</span>
+        {pseudoMatrixStates.map((state) => (
+          <span key={state.key} style={pseudoMatrixLabelCellStyle}>
+            {state.label}
+          </span>
+        ))}
+      </div>
+      {pseudoMatrixRows.map((row) => (
+        <div key={row.key} style={pseudoMatrixGridStyle}>
+          <span style={pseudoMatrixLabelCellStyle}>{row.label}</span>
+          {pseudoMatrixStates.map((state) => (
+            <div key={state.key}>{renderPseudoStateCell(row, state.key)}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    const disabledControls = canvas
+      .getAllByRole('button')
+      .filter((button) => button.hasAttribute('disabled'));
+    await expect(disabledControls.length).toBeGreaterThan(0);
+  },
+};
+
+export const PageDistributionAndBoundaryValidationBundle: Story = {
+  name: 'Page distribution + boundary/a11y validation (bundle)',
+  parameters: {
+    layout: 'padded',
+    docs: {
+      canvas: { sourceState: 'none' },
+      description: {
+        story:
+          'Combined validation bundle covering page-distribution layouts, first/last boundary disabled controls, and aria-current semantics in one static reference story.',
+      },
+    },
+    controls: { disable: true },
+  },
+  render: () => (
+    <div style={{ display: 'grid', gap: 'var(--mds-spacing-md)' }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '24rem 1fr',
+          alignItems: 'center',
+          gap: 'var(--mds-spacing-lg)',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--mds-font-size-paragraph-small)',
+            color: 'var(--mds-text-subtle)',
+          }}
+        >
+          First page disabled previous button
+        </p>
+        <div data-testid="testing-bundle-first-disabled">
+          <Pagination
+            totalPages={10}
+            currentPage={1}
+            ariaLabel="Pagination first page disabled previous"
+            onPageChange={() => {}}
+          />
+        </div>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '24rem 1fr',
+          alignItems: 'center',
+          gap: 'var(--mds-spacing-lg)',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--mds-font-size-paragraph-small)',
+            color: 'var(--mds-text-subtle)',
+          }}
+        >
+          Last page disabled next button
+        </p>
+        <div data-testid="testing-bundle-last-disabled">
+          <Pagination
+            totalPages={10}
+            currentPage={10}
+            ariaLabel="Pagination last page disabled next"
+            onPageChange={() => {}}
+          />
+        </div>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '24rem 1fr',
+          alignItems: 'center',
+          gap: 'var(--mds-spacing-lg)',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--mds-font-size-paragraph-small)',
+            color: 'var(--mds-text-subtle)',
+          }}
+        >
+          Aria labels and current page indicator
+        </p>
+        <div data-testid="testing-bundle-aria">
+          <Pagination
+            totalPages={5}
+            currentPage={3}
+            ariaLabel="Pagination aria current page example"
+            onPageChange={() => {}}
+          />
+        </div>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '24rem 1fr',
+          alignItems: 'center',
+          gap: 'var(--mds-spacing-lg)',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--mds-font-size-paragraph-small)',
+            color: 'var(--mds-text-subtle)',
+          }}
+        >
+          Current page in middle
+        </p>
+        <Pagination
+          totalPages={10}
+          currentPage={5}
+          ariaLabel="Pagination middle page distribution"
+          onPageChange={() => {}}
+        />
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '24rem 1fr',
+          alignItems: 'center',
+          gap: 'var(--mds-spacing-lg)',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--mds-font-size-paragraph-small)',
+            color: 'var(--mds-text-subtle)',
+          }}
+        >
+          Few pages
+        </p>
+        <Pagination
+          totalPages={3}
+          currentPage={2}
+          ariaLabel="Pagination few pages example"
+          onPageChange={() => {}}
+        />
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '24rem 1fr',
+          alignItems: 'center',
+          gap: 'var(--mds-spacing-lg)',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--mds-font-size-paragraph-small)',
+            color: 'var(--mds-text-subtle)',
+          }}
+        >
+          Grouped variant (prev/next only)
+        </p>
+        <Pagination
+          totalPages={10}
+          currentPage={5}
+          variant="grouped"
+          ariaLabel="Pagination grouped controls example"
+          onPageChange={() => {}}
+        />
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '24rem 1fr',
+          alignItems: 'center',
+          gap: 'var(--mds-spacing-lg)',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--mds-font-size-paragraph-small)',
+            color: 'var(--mds-text-subtle)',
+          }}
+        >
+          Large page count with capped 9-slot window
+        </p>
+        <Pagination
+          totalPages={20}
+          currentPage={10}
+          ariaLabel="Pagination large page count example"
+          onPageChange={() => {}}
+        />
+      </div>
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    const firstDisabledSection = canvas.getByTestId(
+      'testing-bundle-first-disabled',
+    );
+    const firstPrevBtn = firstDisabledSection.querySelector(
+      'button[aria-label="Previous page"]',
+    ) as HTMLButtonElement | null;
+    if (!firstPrevBtn) {
+      throw new Error('First-page previous button not found');
+    }
+    await expect(firstPrevBtn).toBeDisabled();
+
+    const lastDisabledSection = canvas.getByTestId(
+      'testing-bundle-last-disabled',
+    );
+    const lastNextBtn = lastDisabledSection.querySelector(
+      'button[aria-label="Next page"]',
+    ) as HTMLButtonElement | null;
+    if (!lastNextBtn) {
+      throw new Error('Last-page next button not found');
+    }
+    await expect(lastNextBtn).toBeDisabled();
+
+    const ariaSection = canvas.getByTestId('testing-bundle-aria');
+    const page3Btn = ariaSection.querySelector(
+      'button[aria-label="Page 3"]',
+    ) as HTMLButtonElement | null;
+    if (!page3Btn) {
+      throw new Error('ARIA Page 3 button not found');
+    }
+    await expect(page3Btn).toHaveAttribute('aria-current', 'page');
+  },
+};
+
+export const RightToLeft: Story = {
+  args: {
+    totalPages: 10,
+    currentPage: 5,
+  },
+  decorators: [
+    (Story) => (
+      <div dir="rtl">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['test', 'stable'],
+  play: async ({ canvas }) => {
+    const nav = canvas.getByRole('navigation');
+    await expect(nav).toHaveAttribute('aria-label', 'Pagination');
+  },
+};

--- a/components/pagination/Pagination.test.tsx
+++ b/components/pagination/Pagination.test.tsx
@@ -1,0 +1,392 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { PaginationProps } from './Pagination';
+import { Pagination } from './Pagination';
+
+const defaultProps: PaginationProps = {
+  totalPages: 5,
+  currentPage: 1,
+  onPageChange: () => {},
+};
+
+function renderPagination(overrides: Partial<PaginationProps> = {}) {
+  return render(<Pagination {...defaultProps} {...overrides} />);
+}
+
+describe('Pagination: Unit Tests', () => {
+  it('applies base mds class names', () => {
+    const { container } = renderPagination();
+    const nav = container.querySelector('nav');
+    expect(nav?.classList.contains('mds-pagination')).toBe(true);
+    expect(nav?.classList.contains('mds-pagination--full')).toBe(true);
+  });
+
+  it.each([
+    {
+      caseName: 'full variant by default',
+      props: {},
+      expectedClass: 'mds-pagination--full',
+    },
+    {
+      caseName: 'full variant when variant prop is full',
+      props: { variant: 'full' as const },
+      expectedClass: 'mds-pagination--full',
+    },
+    {
+      caseName: 'grouped variant when variant prop is grouped',
+      props: { totalPages: 10, currentPage: 5, variant: 'grouped' as const },
+      expectedClass: 'mds-pagination--grouped',
+    },
+    {
+      caseName: 'full variant for totalPages = 2 (no auto-grouped behavior)',
+      props: { totalPages: 2 },
+      expectedClass: 'mds-pagination--full',
+    },
+  ])('applies $expectedClass for $caseName', ({ props, expectedClass }) => {
+    const { container } = renderPagination(props);
+    const nav = container.querySelector('nav');
+    expect(nav?.classList.contains(expectedClass)).toBe(true);
+  });
+
+  it('falls back to the full variant when an invalid variant is provided', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { container } = renderPagination({ variant: 'invalid' });
+    const nav = container.querySelector('nav');
+
+    expect(nav?.classList.contains('mds-pagination--full')).toBe(true);
+    expect(container.querySelector('.mds-pagination__pages')).not.toBeNull();
+
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to the default page label formatter when an invalid formatter is provided', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderPagination({
+      currentPage: 3,
+      pageLabelFormatter:
+        'invalid' as unknown as PaginationProps['pageLabelFormatter'],
+    });
+
+    expect(screen.getByRole('button', { name: 'Page 3' })).toBeInTheDocument();
+
+    warnSpy.mockRestore();
+  });
+
+  it('returns null when total pages is less than 2', () => {
+    const { container } = renderPagination({ totalPages: 1 });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders previous and next buttons', () => {
+    renderPagination({ currentPage: 3 });
+    const prevBtn = screen.getByRole('button', { name: /previous page/i });
+    const nextBtn = screen.getByRole('button', { name: /next page/i });
+    expect(prevBtn).toBeInTheDocument();
+    expect(nextBtn).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      caseName: 'previous button on first page',
+      currentPage: 1,
+      buttonName: /previous page/i,
+    },
+    {
+      caseName: 'next button on last page',
+      currentPage: 5,
+      buttonName: /next page/i,
+    },
+  ])('disables $caseName', ({ currentPage, buttonName }) => {
+    renderPagination({ currentPage });
+    const button = screen.getByRole('button', { name: buttonName });
+    expect(button).toBeDisabled();
+  });
+
+  it('renders page numbers in full variant', () => {
+    renderPagination({ currentPage: 3 });
+    expect(
+      screen.getByRole('button', { name: /^page 1$/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /page 3/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /page 5/i })).toBeInTheDocument();
+  });
+
+  it('marks only the current page with current-state attributes', () => {
+    renderPagination({ currentPage: 3 });
+
+    const currentPageBtn = screen.getByRole('button', { name: /page 3/i });
+    const page1Btn = screen.getByRole('button', { name: /page 1/i });
+
+    expect(currentPageBtn).toHaveAttribute('aria-current', 'page');
+    expect(currentPageBtn).toHaveAttribute('data-current', 'true');
+    expect(page1Btn).not.toHaveAttribute('aria-current');
+  });
+
+  it('keeps a single current page when the ellipsis layout changes across threshold navigation', () => {
+    const { container, rerender } = renderPagination({
+      totalPages: 15,
+      currentPage: 5,
+    });
+
+    expect(screen.getByRole('button', { name: /page 5/i })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(
+      container.querySelectorAll('.mds-pagination__ellipsis'),
+    ).toHaveLength(1);
+
+    rerender(
+      <Pagination
+        {...defaultProps}
+        totalPages={15}
+        currentPage={6}
+        onPageChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /page 6/i })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('button', { name: /page 5/i })).not.toHaveAttribute(
+      'aria-current',
+    );
+    expect(
+      container.querySelectorAll('.mds-pagination__ellipsis'),
+    ).toHaveLength(2);
+    expect(container.querySelectorAll('[aria-current="page"]')).toHaveLength(1);
+  });
+
+  it('updates visible selected page immediately while waiting for a delayed controlled update', async () => {
+    function DelayedParentPagination() {
+      const [page, setPage] = useState(5);
+
+      return (
+        <Pagination
+          totalPages={15}
+          currentPage={page}
+          onPageChange={(nextPage) => {
+            setTimeout(() => setPage(nextPage), 60);
+          }}
+        />
+      );
+    }
+
+    render(<DelayedParentPagination />);
+
+    await userEvent.click(screen.getByRole('button', { name: /page 6/i }));
+
+    expect(screen.getByRole('button', { name: /page 6/i })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('button', { name: /page 5/i })).not.toHaveAttribute(
+      'aria-current',
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /page 6/i })).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+    });
+  });
+
+  it('does not render page numbers when variant is grouped', () => {
+    const { container } = renderPagination({
+      totalPages: 10,
+      currentPage: 5,
+      variant: 'grouped',
+    });
+    expect(container.querySelector('.mds-pagination__pages')).toBeNull();
+  });
+
+  it('renders page numbers with full variant for totalPages 2', () => {
+    renderPagination({ totalPages: 2 });
+    expect(
+      screen.getByRole('button', { name: /^page 1$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^page 2$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      caseName: 'page button is clicked',
+      currentPage: 1,
+      targetName: /page 3/i,
+      expectedPage: 3,
+    },
+    {
+      caseName: 'next button is clicked',
+      currentPage: 2,
+      targetName: /next page/i,
+      expectedPage: 3,
+    },
+    {
+      caseName: 'previous button is clicked',
+      currentPage: 3,
+      targetName: /previous page/i,
+      expectedPage: 2,
+    },
+  ])(
+    'calls onPageChange when $caseName',
+    async ({ currentPage, targetName, expectedPage }) => {
+      const handlePageChange = vi.fn();
+      renderPagination({ currentPage, onPageChange: handlePageChange });
+
+      await userEvent.click(screen.getByRole('button', { name: targetName }));
+      expect(handlePageChange).toHaveBeenCalledWith(expectedPage);
+    },
+  );
+
+  it.each([
+    {
+      caseName: 'disabled previous button on first page is clicked',
+      currentPage: 1,
+      targetName: /previous page/i,
+    },
+    {
+      caseName: 'disabled next button on last page is clicked',
+      currentPage: 5,
+      targetName: /next page/i,
+    },
+  ])(
+    'does not call onPageChange when $caseName',
+    async ({ currentPage, targetName }) => {
+      const handlePageChange = vi.fn();
+      renderPagination({ currentPage, onPageChange: handlePageChange });
+
+      await userEvent.click(screen.getByRole('button', { name: targetName }));
+      expect(handlePageChange).not.toHaveBeenCalled();
+    },
+  );
+
+  it('forwards extra props to nav element', () => {
+    renderPagination({ 'data-testid': 'custom-pagination' });
+    expect(screen.getByTestId('custom-pagination')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = renderPagination({ className: 'custom-class' });
+    const nav = container.querySelector('nav');
+    expect(nav?.classList.contains('custom-class')).toBe(true);
+  });
+
+  it('clamps current page to valid range', () => {
+    renderPagination({ currentPage: 10 });
+    // Should show page 5 as current (clamped from 10 to 5)
+    const currentPageBtn = screen.getByRole('button', { name: /page 5/i });
+    expect(currentPageBtn).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('has aria-label on nav element', () => {
+    const { container } = renderPagination();
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveAttribute('aria-label', 'Pagination');
+  });
+
+  it('uses custom accessible labels when provided', () => {
+    const { container } = renderPagination({
+      currentPage: 3,
+      ariaLabel: 'Course pagination',
+      previousPageLabel: 'Go to previous results page',
+      nextPageLabel: 'Go to next results page',
+      pageLabelFormatter: (page) => `Results page ${page}`,
+    });
+
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveAttribute('aria-label', 'Course pagination');
+    expect(
+      screen.getByRole('button', { name: 'Go to previous results page' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Go to next results page' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Results page 3' }),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      caseName: 'previous button when it can be used',
+      currentPage: 3,
+      buttonName: /previous page/i,
+      expectedTabIndex: '0',
+    },
+    {
+      caseName: 'next button when it can be used',
+      currentPage: 3,
+      buttonName: /next page/i,
+      expectedTabIndex: '0',
+    },
+    {
+      caseName: 'previous button when it is disabled by page boundary',
+      currentPage: 1,
+      buttonName: /previous page/i,
+      expectedTabIndex: '-1',
+    },
+  ])(
+    'sets correct tabindex for $caseName',
+    ({ currentPage, buttonName, expectedTabIndex }) => {
+      renderPagination({ currentPage });
+      const button = screen.getByRole('button', { name: buttonName });
+      expect(button).toHaveAttribute('tabindex', expectedTabIndex);
+    },
+  );
+
+  it('disables all buttons and removes prev/next tab focus when the disabled prop is set', () => {
+    renderPagination({ currentPage: 3, disabled: true });
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBeGreaterThan(0);
+    buttons.forEach((button) => expect(button).toBeDisabled());
+
+    expect(
+      screen.getByRole('button', { name: /previous page/i }),
+    ).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('button', { name: /next page/i })).toHaveAttribute(
+      'tabindex',
+      '-1',
+    );
+  });
+
+  it.each([
+    { caseName: 'page button', targetName: /page 1/i },
+    { caseName: 'next button', targetName: /next page/i },
+  ])(
+    'does not call onPageChange when $caseName is clicked while disabled',
+    async ({ targetName }) => {
+      const handlePageChange = vi.fn();
+      renderPagination({
+        currentPage: 3,
+        disabled: true,
+        onPageChange: handlePageChange,
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: targetName }));
+      expect(handlePageChange).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not submit a surrounding form when a pagination button is clicked', async () => {
+    const handleSubmit = vi.fn((e: SubmitEvent) => e.preventDefault());
+    render(
+      <form onSubmit={handleSubmit}>
+        <Pagination {...defaultProps} currentPage={2} />
+      </form>,
+    );
+
+    const pageButton = screen.getByRole('button', { name: /page 1/i });
+    await userEvent.click(pageButton);
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -1,0 +1,233 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  calculateVisiblePageNumbers,
+  resolvePaginationInputs,
+  useViewportMaxVisible,
+  type PageLabelFormatter,
+} from './pagination.helpers';
+
+const MAX_VISIBLE_ELEMENTS = 9;
+
+export interface PaginationProps extends ComponentPropsWithoutRef<'nav'> {
+  /** Total number of pages */
+  totalPages: number;
+
+  /** Current page number (1-indexed) */
+  currentPage: number;
+
+  /** Callback fired when the page changes */
+  onPageChange: (page: number) => void;
+
+  /** Accessible name for the pagination landmark. */
+  ariaLabel?: string;
+
+  /** Accessible label used for the previous-page button. */
+  previousPageLabel?: string;
+
+  /** Accessible label used for the next-page button. */
+  nextPageLabel?: string;
+
+  /** Returns the accessible label for each numbered page button. */
+  pageLabelFormatter?: PageLabelFormatter;
+
+  /**
+   * Controls which variant of pagination to render.
+   * Accepts a broad string so JS consumers can be validated at runtime.
+   * - `'full'` (default): Shows page numbers between previous and next controls.
+   *   The visible page count reduces automatically as the viewport width narrows
+   *   (9 → 7 → 5 items), and collapses to grouped appearance when the viewport
+   *   is too narrow to fit any page numbers. First and last pages are always shown
+   *   when needed.
+   * - `'grouped'`: Shows only previous and next controls without page numbers.
+   */
+  variant?: string;
+
+  /** Disables all interactive elements, preventing focus, hover, and page-change events. */
+  disabled?: boolean;
+}
+
+export const Pagination = ({
+  totalPages,
+  currentPage,
+  onPageChange,
+  ariaLabel = 'Pagination',
+  previousPageLabel = 'Previous page',
+  nextPageLabel = 'Next page',
+  pageLabelFormatter,
+  variant = 'full',
+  disabled = false,
+  className,
+  ...props
+}: PaginationProps) => {
+  const {
+    resolvedVariant,
+    resolvedPageLabelFormatter,
+    sanitizedTotalPages,
+    sanitizedCurrentPage,
+  } = resolvePaginationInputs(
+    variant,
+    pageLabelFormatter,
+    totalPages,
+    currentPage,
+  );
+  const viewportMaxVisible = useViewportMaxVisible();
+
+  const [pendingCurrentPage, setPendingCurrentPage] = useState<number | null>(
+    null,
+  );
+
+  // Derive effective variant and page-slot count from viewport width.
+  // Explicit 'grouped' is never auto-upgraded; only 'full' adapts.
+  const adaptiveResult =
+    resolvedVariant === 'full' ? viewportMaxVisible : MAX_VISIBLE_ELEMENTS;
+  const effectiveVariant =
+    resolvedVariant === 'full' && adaptiveResult === null
+      ? 'grouped'
+      : resolvedVariant;
+  const maxVisible = adaptiveResult ?? MAX_VISIBLE_ELEMENTS;
+
+  // Clamp current page to valid range
+  const validCurrentPage = Math.max(
+    1,
+    Math.min(sanitizedCurrentPage, sanitizedTotalPages),
+  );
+
+  const previousValidCurrentPageRef = useRef(validCurrentPage);
+
+  // Keep the visual current page responsive while parent state catches up.
+  // Once a controlled currentPage update arrives, return to controlled rendering.
+  useEffect(() => {
+    const didControlledPageChange =
+      previousValidCurrentPageRef.current !== validCurrentPage;
+
+    if (
+      pendingCurrentPage !== null &&
+      (pendingCurrentPage === validCurrentPage || didControlledPageChange)
+    ) {
+      setPendingCurrentPage(null);
+    }
+
+    previousValidCurrentPageRef.current = validCurrentPage;
+  }, [validCurrentPage, pendingCurrentPage]);
+
+  const visualCurrentPage = pendingCurrentPage ?? validCurrentPage;
+
+  const canGoPrevious = visualCurrentPage > 1;
+  const canGoNext = visualCurrentPage < sanitizedTotalPages;
+
+  const {
+    showBoundaryPages,
+    pageNumbers,
+    showLeftEllipsis,
+    showRightEllipsis,
+  } = useMemo(
+    () =>
+      calculateVisiblePageNumbers(
+        visualCurrentPage,
+        sanitizedTotalPages,
+        maxVisible,
+      ),
+    [visualCurrentPage, sanitizedTotalPages, maxVisible],
+  );
+
+  // Only show pagination if there are 2 or more pages
+  if (sanitizedTotalPages < 2) {
+    return null;
+  }
+
+  const handlePageChange = (page: number) => {
+    if (
+      page !== visualCurrentPage &&
+      page >= 1 &&
+      page <= sanitizedTotalPages
+    ) {
+      setPendingCurrentPage(page);
+      onPageChange(page);
+    }
+  };
+
+  const classes = ['mds-pagination', `mds-pagination--${effectiveVariant}`];
+  if (className) {
+    classes.push(className);
+  }
+
+  // First, middle, and last page buttons share identical behavior; keeping the
+  // markup here avoids three nearly identical JSX branches below.
+  const renderPageButton = (page: number) => (
+    <button
+      key={page}
+      type="button"
+      className="mds-pagination__page"
+      onClick={() => handlePageChange(page)}
+      disabled={disabled}
+      aria-label={resolvedPageLabelFormatter(page)}
+      aria-current={page === visualCurrentPage ? 'page' : undefined}
+      data-current={page === visualCurrentPage}
+    >
+      {page}
+    </button>
+  );
+
+  return (
+    <nav className={classes.join(' ')} aria-label={ariaLabel} {...props}>
+      {/* Previous button */}
+      <button
+        type="button"
+        className="mds-pagination__button mds-pagination__button--prev"
+        onClick={() => handlePageChange(visualCurrentPage - 1)}
+        disabled={disabled || !canGoPrevious}
+        aria-label={previousPageLabel}
+        tabIndex={!disabled && canGoPrevious ? 0 : -1}
+      >
+        <i className="fa-solid fa-chevron-left" aria-hidden="true" />
+      </button>
+
+      {/* Page numbers are hidden in the grouped variant. */}
+      {effectiveVariant === 'full' && (
+        <div className="mds-pagination__pages">
+          {showBoundaryPages && renderPageButton(1)}
+
+          {/* Left ellipsis */}
+          {showLeftEllipsis && (
+            <span
+              key="left-ellipsis"
+              className="mds-pagination__ellipsis"
+              aria-hidden="true"
+            >
+              …
+            </span>
+          )}
+
+          {/* Page numbers */}
+          {pageNumbers.map(renderPageButton)}
+
+          {/* Right ellipsis */}
+          {showRightEllipsis && (
+            <span
+              key="right-ellipsis"
+              className="mds-pagination__ellipsis"
+              aria-hidden="true"
+            >
+              …
+            </span>
+          )}
+
+          {showBoundaryPages && renderPageButton(sanitizedTotalPages)}
+        </div>
+      )}
+
+      {/* Next button */}
+      <button
+        type="button"
+        className="mds-pagination__button mds-pagination__button--next"
+        onClick={() => handlePageChange(visualCurrentPage + 1)}
+        disabled={disabled || !canGoNext}
+        aria-label={nextPageLabel}
+        tabIndex={!disabled && canGoNext ? 0 : -1}
+      >
+        <i className="fa-solid fa-chevron-right" aria-hidden="true" />
+      </button>
+    </nav>
+  );
+};

--- a/components/pagination/index.tsx
+++ b/components/pagination/index.tsx
@@ -1,0 +1,1 @@
+export * from './Pagination';

--- a/components/pagination/pagination.css
+++ b/components/pagination/pagination.css
@@ -1,0 +1,139 @@
+.mds-pagination {
+  display: flex;
+  gap: var(--mds-spacing-xxs);
+  align-items: center;
+  flex-wrap: wrap;
+  font-family: inherit;
+  direction: inherit;
+}
+
+/* Shared base styles for buttons and page items */
+.mds-pagination__button,
+.mds-pagination__page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  min-height: 34px;
+  padding: var(--mds-spacing-xs);
+  border: var(--mds-stroke-weight-sm) solid transparent;
+  border-radius: var(--mds-border-radius-xs);
+  background-color: transparent;
+  color: var(--mds-text-default);
+  font-size: inherit;
+  font-family: inherit;
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* Keep hover affordance on prev/next controls only. Page-number buttons must
+   switch state atomically to avoid visible handoff when ellipsis positions move. */
+.mds-pagination__button {
+  transition: background-color 150ms ease;
+}
+
+.mds-pagination__page {
+  transition: none;
+}
+
+.mds-pagination__button:hover:not(:disabled),
+.mds-pagination__page:hover:not(:disabled) {
+  background-color: var(--mds-bg-interactive-secondary-hover);
+}
+
+.mds-pagination__button:active:not(:disabled),
+.mds-pagination__page:active:not(:disabled) {
+  background-color: var(--mds-bg-interactive-secondary-active);
+}
+
+.mds-pagination__button:focus,
+.mds-pagination__page:focus {
+  box-shadow: none;
+  outline: none;
+}
+
+.mds-pagination__button:focus-visible:not(:disabled),
+.mds-pagination__page:focus-visible:not(:disabled) {
+  outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
+  outline-offset: var(--mds-spacing-offset);
+  box-shadow: none;
+}
+
+.mds-pagination__button:disabled,
+.mds-pagination__page:disabled {
+  color: var(--mds-text-muted);
+  cursor: not-allowed;
+}
+
+/* Icon sizing */
+.mds-pagination__button i {
+  /* width/font-size use --mds-icons-sm (= scale-600 = 1rem = 16px, the icon md size). */
+  width: var(--mds-icons-sm);
+  font-size: var(--mds-icons-sm);
+  line-height: var(--mds-line-height-paragraph-xs);
+}
+
+/* Full variant */
+.mds-pagination--full .mds-pagination__pages {
+  display: flex;
+  gap: var(--mds-spacing-xxs);
+  align-items: center;
+}
+
+/* Page items */
+.mds-pagination__page {
+  line-height: var(--mds-line-height-paragraph-xs);
+}
+
+/* Current page state */
+.mds-pagination__page[data-current='true'] {
+  background-color: var(--mds-bg-interactive-primary-default);
+  color: var(--mds-text-inverse);
+}
+
+.mds-pagination__page[data-current='true']:disabled {
+  background-color: transparent;
+  color: var(--mds-text-muted);
+}
+
+.mds-pagination__page[data-current='true']:hover:not(:disabled) {
+  background-color: var(--mds-bg-interactive-primary-hover);
+}
+
+.mds-pagination__page[data-current='true']:active:not(:disabled) {
+  background-color: var(--mds-bg-interactive-primary-active);
+}
+
+.mds-pagination__page[data-current='true']:focus-visible {
+  outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
+  outline-offset: var(--mds-spacing-offset);
+  box-shadow: none;
+}
+
+/* Ellipsis */
+.mds-pagination__ellipsis {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  min-height: 34px;
+  color: var(--mds-text-muted);
+  user-select: none;
+  pointer-events: none;
+}
+
+/* Grouped variant - only shows prev/next buttons */
+.mds-pagination--grouped .mds-pagination__pages {
+  display: none;
+}
+
+/* Grouped button styling */
+.mds-pagination--grouped .mds-pagination__button {
+  border-color: var(--mds-border-interactive-secondary-default);
+}
+
+/* Flip prev/next chevrons in RTL so they point in the correct travel direction */
+[dir='rtl'] .mds-pagination__button i {
+  transform: scaleX(-1);
+}

--- a/components/pagination/pagination.helpers.test.tsx
+++ b/components/pagination/pagination.helpers.test.tsx
@@ -1,0 +1,210 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  calculateVisiblePageNumbers,
+  resolvePaginationInputs,
+  useViewportMaxVisible,
+} from './pagination.helpers';
+
+function ViewportProbe() {
+  const viewportMaxVisible = useViewportMaxVisible();
+
+  return (
+    <output data-testid="viewport-max-visible">
+      {String(viewportMaxVisible)}
+    </output>
+  );
+}
+
+describe('pagination.helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns all pages without ellipses when everything fits within the visible budget', () => {
+    expect(calculateVisiblePageNumbers(3, 5, 9)).toEqual({
+      showBoundaryPages: false,
+      showLeftEllipsis: false,
+      showRightEllipsis: false,
+      pageNumbers: [1, 2, 3, 4, 5],
+    });
+  });
+
+  it('returns the expected page windows for near-start, middle, and near-end positions', () => {
+    expect(calculateVisiblePageNumbers(1, 15, 9)).toEqual({
+      showBoundaryPages: true,
+      showLeftEllipsis: false,
+      showRightEllipsis: true,
+      pageNumbers: [2, 3, 4, 5, 6, 7],
+    });
+
+    expect(calculateVisiblePageNumbers(8, 15, 9)).toEqual({
+      showBoundaryPages: true,
+      showLeftEllipsis: true,
+      showRightEllipsis: true,
+      pageNumbers: [6, 7, 8, 9, 10],
+    });
+
+    expect(calculateVisiblePageNumbers(15, 15, 9)).toEqual({
+      showBoundaryPages: true,
+      showLeftEllipsis: true,
+      showRightEllipsis: false,
+      pageNumbers: [9, 10, 11, 12, 13, 14],
+    });
+  });
+
+  it('resolves valid inputs without warnings', () => {
+    const formatter = vi.fn((page: number) => `Results page ${page}`);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const resolvedInputs = resolvePaginationInputs('grouped', formatter, 10, 3);
+
+    expect(resolvedInputs.resolvedVariant).toBe('grouped');
+    expect(resolvedInputs.sanitizedTotalPages).toBe(10);
+    expect(resolvedInputs.sanitizedCurrentPage).toBe(3);
+    expect(resolvedInputs.resolvedPageLabelFormatter(4)).toBe('Results page 4');
+    expect(formatter).toHaveBeenCalledWith(4);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back and warns for invalid runtime inputs', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const resolvedInputs = resolvePaginationInputs(
+      'invalid',
+      'bad formatter' as never,
+      5.8,
+      -3,
+    );
+
+    expect(resolvedInputs.resolvedVariant).toBe('full');
+    expect(resolvedInputs.sanitizedTotalPages).toBe(5);
+    expect(resolvedInputs.sanitizedCurrentPage).toBe(1);
+    expect(resolvedInputs.resolvedPageLabelFormatter(2)).toBe('Page 2');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[MDS Pagination] Invalid variant "invalid". Falling back to "full". Allowed: full, grouped',
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[MDS Pagination] Invalid pageLabelFormatter "bad formatter". Falling back to the default page label formatter.',
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[MDS Pagination] Invalid totalPages "5.8". Falling back to 5.',
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[MDS Pagination] Invalid currentPage "-3". Falling back to 1.',
+    );
+  });
+
+  it('tracks viewport changes via resize events when matchMedia is unavailable', () => {
+    const originalMatchMedia = window.matchMedia;
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    window.innerWidth = 500;
+    render(<ViewportProbe />);
+    expect(screen.getByTestId('viewport-max-visible')).toHaveTextContent(
+      'null',
+    );
+
+    act(() => {
+      window.innerWidth = 800;
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(screen.getByTestId('viewport-max-visible')).toHaveTextContent('7');
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it('tracks breakpoint changes via media query listeners and cleans them up on unmount', () => {
+    const originalMatchMedia = window.matchMedia;
+    const listeners: Array<() => void> = [];
+    const addEventListener = vi.fn((_event: string, listener: () => void) => {
+      listeners.push(listener);
+    });
+    const removeEventListener = vi.fn();
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({
+        addEventListener,
+        removeEventListener,
+        matches: false,
+        media: '',
+      })),
+    });
+
+    window.innerWidth = 500;
+    const { unmount } = render(<ViewportProbe />);
+    expect(screen.getByTestId('viewport-max-visible')).toHaveTextContent(
+      'null',
+    );
+    expect(addEventListener).toHaveBeenCalledTimes(3);
+
+    act(() => {
+      window.innerWidth = 1000;
+      listeners.forEach((listener) => listener());
+    });
+
+    expect(screen.getByTestId('viewport-max-visible')).toHaveTextContent('9');
+
+    unmount();
+    expect(removeEventListener).toHaveBeenCalledTimes(3);
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it('supports the legacy media query listener API', () => {
+    const originalMatchMedia = window.matchMedia;
+    const listeners: Array<() => void> = [];
+    const addListener = vi.fn((listener: () => void) => {
+      listeners.push(listener);
+    });
+    const removeListener = vi.fn();
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({
+        addListener,
+        removeListener,
+        matches: false,
+        media: '',
+      })),
+    });
+
+    window.innerWidth = 700;
+    const { unmount } = render(<ViewportProbe />);
+    expect(screen.getByTestId('viewport-max-visible')).toHaveTextContent('5');
+    expect(addListener).toHaveBeenCalledTimes(3);
+
+    act(() => {
+      window.innerWidth = 1000;
+      listeners.forEach((listener) => listener());
+    });
+
+    expect(screen.getByTestId('viewport-max-visible')).toHaveTextContent('9');
+
+    unmount();
+    expect(removeListener).toHaveBeenCalledTimes(3);
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+});

--- a/components/pagination/pagination.helpers.ts
+++ b/components/pagination/pagination.helpers.ts
@@ -1,0 +1,270 @@
+import { useEffect, useState } from 'react';
+
+export type PaginationVariant = 'full' | 'grouped';
+export type PageLabelFormatter = (page: number) => string;
+
+interface ResolvedPaginationInputs {
+  resolvedVariant: PaginationVariant;
+  resolvedPageLabelFormatter: PageLabelFormatter;
+  sanitizedTotalPages: number;
+  sanitizedCurrentPage: number;
+}
+
+export const MAX_VISIBLE_ELEMENTS = 9;
+
+const allowedVariants: PaginationVariant[] = ['full', 'grouped'];
+const VIEWPORT_BREAKPOINT_MEDIA_QUERIES = [
+  '(min-width: 576px)',
+  '(min-width: 768px)',
+  '(min-width: 992px)',
+] as const;
+const defaultPageLabelFormatter: PageLabelFormatter = (page) => `Page ${page}`;
+
+/**
+ * Returns how many page-number slots to show based on the current viewport width.
+ * Returns null when the viewport is too narrow for even a minimal 5-item row,
+ * which signals an auto-collapse to grouped appearance.
+ *
+ * Thresholds align with MDS / Bootstrap 5 breakpoints:
+ *   xxs  < 576 px → null  (grouped, no page numbers)
+ *   sm  ≥ 576 px →    5
+ *   md  ≥ 768 px →    7
+ *   lg  ≥ 992 px →    9
+ */
+function getViewportMaxVisible(): number | null {
+  if (typeof window === 'undefined') return MAX_VISIBLE_ELEMENTS;
+  const w = window.innerWidth;
+  if (w >= 992) return 9;
+  if (w >= 768) return 7;
+  if (w >= 576) return 5;
+  return null;
+}
+
+/**
+ * Calculate which page numbers to display given the current page, total pages,
+ * and the maximum number of visible slots (boundaries + ellipses + center pages).
+ *
+ * Slot accounting for any maxVisible M:
+ *   Near start / near end (1 ellipsis): 1 boundary + M-3 center + 1 ellipsis + 1 boundary
+ *   Middle (2 ellipses):                1 boundary + 1 ellipsis + M-4 center + 1 ellipsis + 1 boundary
+ */
+export function calculateVisiblePageNumbers(
+  currentPage: number,
+  totalPages: number,
+  maxVisible: number,
+): {
+  showBoundaryPages: boolean;
+  showLeftEllipsis: boolean;
+  showRightEllipsis: boolean;
+  pageNumbers: number[];
+} {
+  // All pages fit within budget — no boundary markers or ellipses needed.
+  if (totalPages <= maxVisible) {
+    return {
+      showBoundaryPages: false,
+      showLeftEllipsis: false,
+      showRightEllipsis: false,
+      pageNumbers: Array.from({ length: totalPages }, (_, i) => i + 1),
+    };
+  }
+
+  // Center pages when a single ellipsis is visible (near start or near end).
+  const middleForSingle = maxVisible - 3;
+  // Center pages when both ellipses are visible (middle position).
+  const middleForDouble = maxVisible - 4;
+  const halfMiddle = Math.floor(middleForDouble / 2);
+
+  // Page at which the left ellipsis first appears (near-start → middle transition).
+  const nearStartThreshold = 1 + middleForSingle - halfMiddle;
+  // Page at which the right ellipsis disappears (middle → near-end transition).
+  const nearEndThreshold = totalPages - nearStartThreshold + 1;
+
+  if (currentPage <= nearStartThreshold) {
+    const startPage = 2;
+    const endPage = 1 + middleForSingle;
+    return {
+      showBoundaryPages: true,
+      showLeftEllipsis: false,
+      showRightEllipsis: true,
+      pageNumbers: Array.from(
+        { length: endPage - startPage + 1 },
+        (_, i) => startPage + i,
+      ),
+    };
+  }
+
+  if (currentPage >= nearEndThreshold) {
+    const endPage = totalPages - 1;
+    const startPage = endPage - middleForSingle + 1;
+    return {
+      showBoundaryPages: true,
+      showLeftEllipsis: true,
+      showRightEllipsis: false,
+      pageNumbers: Array.from(
+        { length: endPage - startPage + 1 },
+        (_, i) => startPage + i,
+      ),
+    };
+  }
+
+  // Middle position — both ellipses visible.
+  const startPage = currentPage - halfMiddle;
+  const endPage = currentPage + middleForDouble - halfMiddle - 1;
+  return {
+    showBoundaryPages: true,
+    showLeftEllipsis: true,
+    showRightEllipsis: true,
+    pageNumbers: Array.from(
+      { length: endPage - startPage + 1 },
+      (_, i) => startPage + i,
+    ),
+  };
+}
+
+function warnInvalidProp(
+  propName: string,
+  value: unknown,
+  fallbackDescription: string,
+) {
+  if (!import.meta.env.DEV) {
+    return;
+  }
+
+  console.warn(
+    `[MDS Pagination] Invalid ${propName} "${String(value)}". Falling back to ${fallbackDescription}.`,
+  );
+}
+
+function sanitizePositiveInteger(
+  value: number,
+  propName: 'totalPages' | 'currentPage',
+  fallbackValue: number,
+): number {
+  if (!Number.isFinite(value)) {
+    warnInvalidProp(propName, value, String(fallbackValue));
+    return fallbackValue;
+  }
+
+  const normalizedValue = Math.trunc(value);
+  if (normalizedValue < 1 || normalizedValue !== value) {
+    const safeValue = Math.max(1, normalizedValue);
+    warnInvalidProp(propName, value, String(safeValue));
+    return safeValue;
+  }
+
+  return normalizedValue;
+}
+
+function addMediaQueryChangeListener(
+  mediaQueryList: MediaQueryList,
+  listener: () => void,
+) {
+  // Safari still supports the older addListener/removeListener pair, so keep
+  // this compatibility layer until the library drops that browser range.
+  if (typeof mediaQueryList.addEventListener === 'function') {
+    mediaQueryList.addEventListener('change', listener);
+    return;
+  }
+
+  mediaQueryList.addListener(listener);
+}
+
+function removeMediaQueryChangeListener(
+  mediaQueryList: MediaQueryList,
+  listener: () => void,
+) {
+  if (typeof mediaQueryList.removeEventListener === 'function') {
+    mediaQueryList.removeEventListener('change', listener);
+    return;
+  }
+
+  mediaQueryList.removeListener(listener);
+}
+
+export function useViewportMaxVisible() {
+  // Initialise from current viewport width so the first render already matches the viewport.
+  const [viewportMaxVisible, setViewportMaxVisible] = useState<number | null>(
+    getViewportMaxVisible,
+  );
+
+  useEffect(() => {
+    // window is available in browser environments; absent in jsdom / SSR.
+    if (typeof window === 'undefined') return;
+
+    const handler = () => setViewportMaxVisible(getViewportMaxVisible());
+
+    if (typeof window.matchMedia !== 'function') {
+      window.addEventListener('resize', handler);
+      return () => window.removeEventListener('resize', handler);
+    }
+
+    const mediaQueryLists = VIEWPORT_BREAKPOINT_MEDIA_QUERIES.map((query) =>
+      window.matchMedia(query),
+    );
+
+    mediaQueryLists.forEach((mediaQueryList) => {
+      addMediaQueryChangeListener(mediaQueryList, handler);
+    });
+
+    return () => {
+      mediaQueryLists.forEach((mediaQueryList) => {
+        removeMediaQueryChangeListener(mediaQueryList, handler);
+      });
+    };
+  }, []);
+
+  return viewportMaxVisible;
+}
+
+function resolvePaginationVariant(variant: string): PaginationVariant {
+  if (
+    import.meta.env.DEV &&
+    variant &&
+    !allowedVariants.includes(variant as PaginationVariant)
+  ) {
+    console.warn(
+      `[MDS Pagination] Invalid variant "${variant}". Falling back to "full". Allowed: ${allowedVariants.join(', ')}`,
+    );
+  }
+
+  return allowedVariants.includes(variant as PaginationVariant)
+    ? (variant as PaginationVariant)
+    : 'full';
+}
+
+function resolvePageLabelFormatter(pageLabelFormatter?: PageLabelFormatter) {
+  if (
+    pageLabelFormatter !== undefined &&
+    typeof pageLabelFormatter !== 'function'
+  ) {
+    warnInvalidProp(
+      'pageLabelFormatter',
+      pageLabelFormatter,
+      'the default page label formatter',
+    );
+  }
+
+  return typeof pageLabelFormatter === 'function'
+    ? pageLabelFormatter
+    : defaultPageLabelFormatter;
+}
+
+export function resolvePaginationInputs(
+  variant: string,
+  pageLabelFormatter: PageLabelFormatter | undefined,
+  totalPages: number,
+  currentPage: number,
+): ResolvedPaginationInputs {
+  // Resolve every JS-facing input in one place so the render path can assume
+  // normalized values and stay focused on layout decisions.
+  return {
+    resolvedVariant: resolvePaginationVariant(variant),
+    resolvedPageLabelFormatter: resolvePageLabelFormatter(pageLabelFormatter),
+    sanitizedTotalPages: sanitizePositiveInteger(totalPages, 'totalPages', 1),
+    sanitizedCurrentPage: sanitizePositiveInteger(
+      currentPage,
+      'currentPage',
+      1,
+    ),
+  };
+}


### PR DESCRIPTION
## Description

This PR introduces the new `Pagination` component to the Moodle Design System with support for two rendering modes and state-aware interaction patterns:

- `full` mode for multi-page navigation with page numbers and ellipsis handling
- `grouped` mode for previous/next-only navigation when total-page context is intentionally omitted

The implementation follows the component checklist workflow and aligns naming/behaviour across code, Storybook, and Figma. The main goal is to provide a reusable, accessible pagination primitive that can be consumed consistently in Moodle interfaces while preserving token-driven styling and predictable keyboard/screen-reader behaviour.

### General approach

1. Design-first parity

- Use the Figma source as the behaviour and visual reference baseline: https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=8467-37488&m=dev
- Verify mode semantics (`full` vs `grouped`), control affordances, and state transitions (`default`, `hover`, `active`, `disabled`) against the design intent.

2. API and rendering model

- Provide a constrained, explicit prop API to avoid ambiguous pagination behaviour.
- Keep rendering logic deterministic for edge cases (small page counts, near-start/end windows, ellipsis placement).
- Ensure invalid/unsupported prop values gracefully fall back to documented defaults.

3. Styling and token compliance

- Use existing `--mds-*` tokens and preserve the project guardrail of no fallback literals where matching tokens exist.
- Keep variants composable via stable class hooks (`mds-*`) and predictable CSS structure.

4. Accessibility and interaction quality

- Maintain correct `aria-current` usage for active page in `full` mode.
- Ensure icon-only controls are labelled (`aria-label`) and disabled states are exposed correctly.
- Validate focus visibility and keyboard navigation behaviour in stories/tests.

5. Verification and rollout readiness

- Cover helper logic with focused unit tests.
- Cover visual/interactive states via Storybook stories and test tags.
- Use the MDS build/checklist guidance as a readiness gate before merge.

## Related Jira or GitHub Issue

- Jira: https://moodle.atlassian.net/browse/MDS-496
- Confluence checklist/reference: https://moodle.atlassian.net/wiki/spaces/MDS/pages/3937632270/Pagination+MSE+and+Build+Checklist
- Figma design reference: https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=8467-37488&m=dev

## Author checklist

### File structure and exports

- [x] All 5 required files present: `ComponentName.tsx`, `component-name.css`, `ComponentName.test.tsx`, `ComponentName.stories.tsx`, `index.tsx`
- [x] `ComponentName.figma.tsx` Code Connect file created and published
- [x] Named and type exports added to `components/index.tsx`
- [x] Component stylesheet imported in `components/index.css`

### TypeScript and props

- [x] Props interface extends the correct React HTML element interface (e.g. `ButtonHTMLAttributes<HTMLButtonElement>`)
- [x] JSDoc comment on each prop
- [x] Constrained props use `allowedValues` runtime validation with a graceful fallback to a documented default
- [x] `...props` spread last on the host element

### Internationalisation

- [x] All user-facing strings accepted as props — no hardcoded text in JSX
- [x] CSS uses logical properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`) for any directional layout
- [x] RTL story added if the component has directional layout

### CSS and tokens

- [x] All CSS values use `var(--mds-*)` tokens — no hardcoded colours, spacing, or typography
- [x] Where a matching token exists, `var(--mds-*)` is used without fallback literals (for example, `var(--mds-spacing-xs)`, not `var(--mds-spacing-xs, 0.5rem)`)

### Tests and stories

- [x] Unit tests cover: `mds-*` class on root, correct classes per variant/size, invalid prop fallback, prop forwarding, disabled state, and label rendering
- [x] Storybook stories cover all documented variants, sizes, and states
- [x] Accessibility tested — Axe WCAG AA scan runs automatically via CI on all stories tagged `test`

### Breaking changes

- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump

### AI context

- [x] Instruction files updated if this component introduces new patterns or anti-patterns

## Cross-system parity

- [x] Component name, prop names, and variant names are consistent across code, Storybook, Figma, and Zeroheight

## Additional Notes

- This draft intentionally follows the component PR template format so it can be copied into a GitHub PR opened with `?template=component.md`.
- Reviewer focus requested:
  - Parity sign-off for grouped/full mode behaviour against Figma node `8467:37488`
  - Validation against MDS-496 acceptance intent
  - Final pass against the Pagination MSE and Build Checklist before merge
