### PR TITLE
feat(ProgressBar): Add new ProgressBar component

### DIFF
--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -147,7 +147,7 @@ Use `interface`, not `type`, for props. Use `import type` for type-only imports.
 
 ## Runtime validation for constrained props
 
-Props with a fixed set of allowed values must use runtime validation with an `allowedValues` array — TypeScript types alone are not enough, because external consumers can pass any string. Accept the prop as a broad type (`string`) in the interface and resolve to a safe default if an invalid value arrives.
+Props with a fixed set of allowed values must use runtime validation with an `allowedValues` array. Keep the public TypeScript API narrow (for example, union literals) for editor/type safety, and still resolve invalid runtime input to a safe default because external JavaScript consumers can pass any value.
 
 Always pair the silent fallback with a development-mode warning so consumers are alerted without affecting production builds:
 

--- a/components/index.css
+++ b/components/index.css
@@ -4,4 +4,5 @@
 @import './checkbox/checkbox.css';
 @import './close-button/close-button.css';
 @import './pagination/pagination.css';
+@import './progress-bar/progress-bar.css';
 @import './radio/radio.css';

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -16,5 +16,8 @@ export type { CloseButtonProps } from './close-button';
 export { Pagination } from './pagination';
 export type { PaginationProps } from './pagination';
 
+export { ProgressBar } from './progress-bar';
+export type { ProgressBarProps } from './progress-bar';
+
 export { Radio } from './radio';
 export type { RadioProps } from './radio';

--- a/components/progress-bar/ProgressBar.figma.tsx
+++ b/components/progress-bar/ProgressBar.figma.tsx
@@ -1,0 +1,189 @@
+import figma from '@figma/code-connect';
+import { ProgressBar } from './ProgressBar';
+
+const url =
+  'https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=8847-672';
+const statusUrl =
+  'https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=8838-290';
+
+const titleProp = figma.string('Title');
+const countProp = figma.string('Count');
+
+const baseLabelExampleProps = {
+  value: 50,
+  status: 'in-progress' as const,
+  animated: false,
+};
+
+const baseStatusExampleProps = {
+  labelVariant: 'title-and-count' as const,
+  animated: false,
+};
+
+// Default state — title-and-count layout.
+figma.connect(ProgressBar, url, {
+  variant: { 'Label variant': 'Title and count' },
+  props: {
+    title: titleProp,
+    count: countProp,
+  },
+  example: ({ title, count }) => (
+    <ProgressBar
+      {...baseLabelExampleProps}
+      labelVariant="title-and-count"
+      title={title}
+      count={count}
+    />
+  ),
+});
+
+// Title-only layout.
+figma.connect(ProgressBar, url, {
+  variant: { 'Label variant': 'Title' },
+  props: {
+    title: titleProp,
+  },
+  example: ({ title }) => (
+    <ProgressBar
+      {...baseLabelExampleProps}
+      labelVariant="title"
+      title={title}
+    />
+  ),
+});
+
+// Inline layout — bar and count in a row.
+figma.connect(ProgressBar, url, {
+  variant: { 'Label variant': 'Inline' },
+  props: {
+    title: titleProp,
+    count: countProp,
+  },
+  example: ({ title, count }) => (
+    <ProgressBar
+      {...baseLabelExampleProps}
+      labelVariant="inline"
+      title={title}
+      count={count}
+    />
+  ),
+});
+
+// No label — bar only.
+figma.connect(ProgressBar, url, {
+  variant: { 'Label variant': 'None' },
+  props: {
+    title: titleProp,
+  },
+  example: ({ title }) => (
+    <ProgressBar {...baseLabelExampleProps} labelVariant="none" title={title} />
+  ),
+});
+
+// 0% value override -> neutral/grey visual.
+figma.connect(ProgressBar, statusUrl, {
+  variant: { Status: 'Empty' },
+  props: {
+    title: titleProp,
+    count: countProp,
+  },
+  example: ({ title, count }) => (
+    <ProgressBar
+      {...baseStatusExampleProps}
+      title={title}
+      count={count}
+      value={0}
+      status="warning"
+    />
+  ),
+});
+
+// In-progress status.
+figma.connect(ProgressBar, statusUrl, {
+  variant: { Status: 'In progress' },
+  props: {
+    title: titleProp,
+    count: countProp,
+  },
+  example: ({ title, count }) => (
+    <ProgressBar
+      {...baseStatusExampleProps}
+      title={title}
+      count={count}
+      value={50}
+      status="in-progress"
+    />
+  ),
+});
+
+// Loading status.
+figma.connect(ProgressBar, statusUrl, {
+  variant: { Status: 'Loading' },
+  props: {
+    title: titleProp,
+    count: countProp,
+  },
+  example: ({ title, count }) => (
+    <ProgressBar
+      {...baseStatusExampleProps}
+      title={title}
+      count={count}
+      value={30}
+      status="loading"
+    />
+  ),
+});
+
+// Error status.
+figma.connect(ProgressBar, statusUrl, {
+  variant: { Status: 'Error' },
+  props: {
+    title: titleProp,
+    count: countProp,
+  },
+  example: ({ title, count }) => (
+    <ProgressBar
+      {...baseStatusExampleProps}
+      title={title}
+      count={count}
+      value={40}
+      status="error"
+    />
+  ),
+});
+
+// Warning status.
+figma.connect(ProgressBar, statusUrl, {
+  variant: { Status: 'Warning' },
+  props: {
+    title: titleProp,
+    count: countProp,
+  },
+  example: ({ title, count }) => (
+    <ProgressBar
+      {...baseStatusExampleProps}
+      title={title}
+      count={count}
+      value={60}
+      status="warning"
+    />
+  ),
+});
+
+// 100% value override -> success/green visual.
+figma.connect(ProgressBar, statusUrl, {
+  variant: { Status: 'Completed' },
+  props: {
+    title: titleProp,
+    count: countProp,
+  },
+  example: ({ title, count }) => (
+    <ProgressBar
+      {...baseStatusExampleProps}
+      title={title}
+      count={count}
+      value={100}
+      status="error"
+    />
+  ),
+});

--- a/components/progress-bar/ProgressBar.stories.tsx
+++ b/components/progress-bar/ProgressBar.stories.tsx
@@ -1,0 +1,315 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+import { ProgressBar } from './ProgressBar';
+
+const meta = {
+  title: 'Components/ProgressBar',
+  component: ProgressBar,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs', 'test', 'stable'],
+  argTypes: {
+    value: {
+      control: { type: 'number' },
+      description:
+        'Current progress value in the range defined by min and max. Fill is normalised from min to max.',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '0' },
+      },
+    },
+    min: {
+      control: { type: 'number' },
+      description: 'Lower bound for the progress range.',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '0' },
+      },
+    },
+    max: {
+      control: { type: 'number' },
+      description: 'Upper bound for the progress range.',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '100' },
+      },
+    },
+    status: {
+      control: { type: 'select' },
+      options: ['in-progress', 'loading', 'error', 'warning'],
+      description:
+        'Visual state — controls fill and track colours only when value is between 1 and 99.',
+      table: {
+        type: {
+          summary: 'in-progress | loading | error | warning',
+        },
+        defaultValue: { summary: 'in-progress' },
+      },
+    },
+    animated: {
+      control: { type: 'boolean' },
+      if: { arg: 'status', eq: 'loading' },
+      description:
+        'Controls striped animation when status is loading. Ignored for non-loading statuses.',
+      table: {
+        type: { summary: 'true | false' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    labelVariant: {
+      control: { type: 'select' },
+      options: ['title-and-count', 'title', 'inline', 'none'],
+      description: 'Controls label layout.',
+      table: {
+        type: { summary: 'title-and-count | title | inline | none' },
+        defaultValue: { summary: 'title-and-count' },
+      },
+    },
+    title: {
+      description:
+        'Pre-translated title text rendered above the bar, or used as the accessible name when no visible label is present.',
+      table: { defaultValue: { summary: '' } },
+    },
+    count: {
+      description:
+        'Pre-translated count or percentage text, e.g. "3 of 10" or "50%". The consuming app owns this string so locale-specific word order, plural rules, and number formatting can come from its i18n layer.',
+      table: { defaultValue: { summary: '' } },
+    },
+  },
+  args: {
+    value: 50,
+    min: 0,
+    max: 100,
+    status: undefined,
+    animated: false,
+    labelVariant: undefined,
+    title: 'Uploading files',
+    count: '5 of 10',
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('progressbar')).toBeVisible();
+  },
+} satisfies Meta<typeof ProgressBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const showcaseParameters = {
+  controls: { disable: true },
+  docs: {
+    canvas: { sourceState: 'none' },
+  },
+} as const;
+
+const showcaseGridStyle = {
+  display: 'grid' as const,
+  gap: 'var(--mds-spacing-md)',
+};
+
+const showcaseRowStyle = {
+  display: 'grid' as const,
+  gridTemplateColumns: 'minmax(10rem, 12rem) minmax(0, 1fr)',
+  gap: 'var(--mds-spacing-md)',
+  alignItems: 'center' as const,
+  minHeight: 'var(--mds-spacing-xxl)',
+};
+
+const showcaseLabelStyle = {
+  color: 'var(--mds-text-subtle)',
+  fontSize: 'var(--mds-font-size-paragraph-small)',
+  fontFamily: 'var(--mds-font-family-base)',
+  fontWeight: 'var(--mds-font-weight-medium)',
+};
+
+export const Default: Story = {};
+
+export const LabelVariants: Story = {
+  parameters: showcaseParameters,
+  play: async ({ canvas }) => {
+    await expect(canvas.getAllByRole('progressbar')).toHaveLength(4);
+  },
+  render: () => (
+    <div style={showcaseGridStyle}>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Title and count</span>
+        <ProgressBar
+          value={50}
+          status="in-progress"
+          labelVariant="title-and-count"
+          title="Uploading files"
+          count="5 of 10"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Title only</span>
+        <ProgressBar
+          value={50}
+          status="in-progress"
+          labelVariant="title"
+          title="Uploading files"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Inline count</span>
+        <ProgressBar
+          value={50}
+          status="in-progress"
+          labelVariant="inline"
+          title="Uploading files"
+          count="5 of 10"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>No visible label</span>
+        <ProgressBar
+          value={50}
+          status="in-progress"
+          labelVariant="none"
+          title="Uploading files"
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const Statuses: Story = {
+  parameters: showcaseParameters,
+  play: async ({ canvas }) => {
+    await expect(canvas.getAllByRole('progressbar')).toHaveLength(6);
+  },
+  render: () => (
+    <div style={showcaseGridStyle}>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Empty (0%)</span>
+        <ProgressBar
+          value={0}
+          status="warning"
+          labelVariant="title-and-count"
+          title="Not started"
+          count="0 of 10"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>In progress</span>
+        <ProgressBar
+          value={50}
+          status="in-progress"
+          labelVariant="title-and-count"
+          title="Uploading files"
+          count="5 of 10"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Loading</span>
+        <ProgressBar
+          value={30}
+          status="loading"
+          labelVariant="title-and-count"
+          title="Loading"
+          count="3 of 10"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Error</span>
+        <ProgressBar
+          value={40}
+          status="error"
+          labelVariant="title-and-count"
+          title="Upload failed"
+          count="4 of 10"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Warning</span>
+        <ProgressBar
+          value={60}
+          status="warning"
+          labelVariant="title-and-count"
+          title="Upload paused"
+          count="6 of 10"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Completed (100%)</span>
+        <ProgressBar
+          value={100}
+          status="error"
+          labelVariant="title-and-count"
+          title="Upload complete"
+          count="10 of 10"
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const Animated: Story = {
+  parameters: showcaseParameters,
+  play: async ({ canvas }) => {
+    await expect(canvas.getAllByRole('progressbar')).toHaveLength(2);
+  },
+  render: () => (
+    <div style={showcaseGridStyle}>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Loading (animated)</span>
+        <ProgressBar
+          value={30}
+          status="loading"
+          animated
+          labelVariant="title-and-count"
+          title="Loading"
+          count="3 of 10"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>Loading (static)</span>
+        <ProgressBar
+          value={30}
+          status="loading"
+          animated={false}
+          labelVariant="title-and-count"
+          title="Loading"
+          count="3 of 10"
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const RightToLeft: Story = {
+  tags: ['test', 'stable'],
+  parameters: showcaseParameters,
+  play: async ({ canvas, canvasElement }) => {
+    await expect(canvas.getAllByRole('progressbar')).toHaveLength(2);
+    await expect(
+      canvasElement.querySelector('.progress-bar-animated'),
+    ).toBeTruthy();
+  },
+  render: () => (
+    <div dir="rtl" style={showcaseGridStyle}>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>جاري رفع الملفات</span>
+        <ProgressBar
+          value={50}
+          status="in-progress"
+          labelVariant="title-and-count"
+          title="جاري رفع الملفات"
+          count="٥ من ١٠"
+        />
+      </div>
+      <div style={showcaseRowStyle}>
+        <span style={showcaseLabelStyle}>جاري التحميل (متحرك)</span>
+        <ProgressBar
+          value={30}
+          status="loading"
+          animated
+          labelVariant="title-and-count"
+          title="جاري التحميل"
+          count="٣ من ١٠"
+        />
+      </div>
+    </div>
+  ),
+};

--- a/components/progress-bar/ProgressBar.test.tsx
+++ b/components/progress-bar/ProgressBar.test.tsx
@@ -1,0 +1,495 @@
+import { render, screen } from '@testing-library/react';
+import fc from 'fast-check';
+import { describe, expect, it, vi } from 'vitest';
+import { fuzzComponent } from '../../tests/utils/fuzzComponent';
+import { ProgressBar, type ProgressBarProps } from './ProgressBar';
+
+describe('ProgressBar: Unit Test', () => {
+  it('applies mds-progress-bar class to the root wrapper element', () => {
+    const { container } = render(<ProgressBar title="Upload" value={50} />);
+    expect(container.firstChild).toHaveClass('mds-progress-bar');
+  });
+
+  it('renders a progressbar role element', () => {
+    render(<ProgressBar title="Upload" value={50} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('uses in-progress visual styling when status is omitted and value is between 1 and 99', () => {
+    const { container } = render(<ProgressBar title="Upload" value={50} />);
+    expect(container.firstChild).toHaveClass('mds-progress-bar--in-progress');
+  });
+
+  it('sets aria-valuenow, aria-valuemin, and aria-valuemax on the track', () => {
+    render(<ProgressBar title="Upload" value={75} />);
+    const track = screen.getByRole('progressbar');
+    expect(track).toHaveAttribute('aria-valuenow', '75');
+    expect(track).toHaveAttribute('aria-valuemin', '0');
+    expect(track).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('supports custom min/max range for aria values and normalized fill width', () => {
+    const { container } = render(
+      <ProgressBar title="Upload" value={230} min={0} max={500} />,
+    );
+    const track = screen.getByRole('progressbar');
+    const fill = container.querySelector('.mds-progress-bar-fill');
+
+    expect(track).toHaveAttribute('aria-valuenow', '230');
+    expect(track).toHaveAttribute('aria-valuemin', '0');
+    expect(track).toHaveAttribute('aria-valuemax', '500');
+    expect(fill).toHaveStyle({ width: '46%' });
+  });
+
+  it('clamps value below 0 to 0', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<ProgressBar title="Upload" value={-10} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '0',
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('clamps value above 100 to 100', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<ProgressBar title="Upload" value={150} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '100',
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('clamps value against custom min/max bounds', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { rerender } = render(
+      <ProgressBar title="Upload" value={2} min={3} max={10} />,
+    );
+
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '3',
+    );
+
+    rerender(<ProgressBar title="Upload" value={15} min={3} max={10} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '10',
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to default range when min/max are invalid', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<ProgressBar title="Upload" value={50} min={10} max={10} />);
+    const track = screen.getByRole('progressbar');
+
+    expect(track).toHaveAttribute('aria-valuemin', '0');
+    expect(track).toHaveAttribute('aria-valuemax', '100');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[MDS ProgressBar] Invalid range'),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('warns in development when value is out of range', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<ProgressBar title="Upload" value={-1} />);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[MDS ProgressBar] value "-1"'),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('applies the status modifier class', () => {
+    const { container } = render(
+      <ProgressBar title="Upload" value={50} status="error" />,
+    );
+    expect(container.firstChild).toHaveClass('mds-progress-bar--error');
+  });
+
+  it('uses neutral visual styling at 0% regardless of status', () => {
+    const { container } = render(
+      <ProgressBar title="Upload" value={0} status="warning" />,
+    );
+    expect(container.firstChild).toHaveClass('mds-progress-bar--empty');
+    expect(container.firstChild).not.toHaveClass('mds-progress-bar--warning');
+  });
+
+  it('uses completed visual styling at 100% regardless of status', () => {
+    const { container } = render(
+      <ProgressBar title="Upload" value={100} status="error" />,
+    );
+    expect(container.firstChild).toHaveClass('mds-progress-bar--completed');
+    expect(container.firstChild).not.toHaveClass('mds-progress-bar--error');
+  });
+
+  it('falls back to in-progress for an invalid status', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container } = render(
+      <ProgressBar title="Upload" value={50} status={'invalid' as never} />,
+    );
+    expect(container.firstChild).toHaveClass('mds-progress-bar--in-progress');
+    vi.restoreAllMocks();
+  });
+
+  it('warns in development when an invalid status is passed', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <ProgressBar title="Upload" value={50} status={'invalid' as never} />,
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[MDS ProgressBar] Invalid status "invalid"'),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('applies the label variant modifier class', () => {
+    const { container } = render(
+      <ProgressBar title="Upload" value={50} labelVariant="inline" />,
+    );
+    expect(container.firstChild).toHaveClass('mds-progress-bar--label-inline');
+  });
+
+  it('renders title text in the title-and-count variant', () => {
+    render(
+      <ProgressBar
+        title="Uploading"
+        count="5 of 10"
+        value={50}
+        labelVariant="title-and-count"
+      />,
+    );
+    expect(screen.getByText('Uploading')).toBeInTheDocument();
+  });
+
+  it('renders count text in the title-and-count variant', () => {
+    render(
+      <ProgressBar
+        title="Uploading"
+        count="5 of 10"
+        value={50}
+        labelVariant="title-and-count"
+      />,
+    );
+    expect(screen.getByText('5 of 10')).toBeInTheDocument();
+  });
+
+  it('renders title but not count in the title variant', () => {
+    render(
+      <ProgressBar
+        title="Uploading"
+        count="5 of 10"
+        value={50}
+        labelVariant="title"
+      />,
+    );
+    expect(screen.getByText('Uploading')).toBeInTheDocument();
+    expect(screen.queryByText('5 of 10')).not.toBeInTheDocument();
+  });
+
+  it('renders count beside the bar in the inline variant', () => {
+    render(
+      <ProgressBar
+        title="Upload"
+        count="5 of 10"
+        value={50}
+        labelVariant="inline"
+      />,
+    );
+    expect(screen.getByText('5 of 10')).toBeInTheDocument();
+    // Title row should not be rendered in inline variant
+    expect(screen.queryByText('Upload')).not.toBeInTheDocument();
+  });
+
+  it('renders no visible label in the none variant', () => {
+    render(
+      <ProgressBar
+        title="Upload"
+        count="5 of 10"
+        value={50}
+        labelVariant="none"
+      />,
+    );
+    expect(screen.queryByText('Upload')).not.toBeInTheDocument();
+    expect(screen.queryByText('5 of 10')).not.toBeInTheDocument();
+  });
+
+  it('uses the title as the accessible name for the progressbar track via aria-labelledby', () => {
+    render(
+      <ProgressBar
+        title="Uploading files"
+        value={50}
+        labelVariant="title-and-count"
+      />,
+    );
+    // The progressbar track should be labelled by the title element
+    expect(
+      screen.getByRole('progressbar', { name: 'Uploading files' }),
+    ).toBeInTheDocument();
+  });
+
+  it('uses an explicit aria-label on the track when provided', () => {
+    render(
+      <ProgressBar
+        title="Uploading files"
+        value={50}
+        labelVariant="none"
+        aria-label="File upload progress"
+      />,
+    );
+    expect(
+      screen.getByRole('progressbar', { name: 'File upload progress' }),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to title as aria-label for inline and none variants without explicit aria-label', () => {
+    render(
+      <ProgressBar title="Uploading files" value={50} labelVariant="none" />,
+    );
+    expect(
+      screen.getByRole('progressbar', { name: 'Uploading files' }),
+    ).toBeInTheDocument();
+  });
+
+  it('applies striped class but not animated class when loading and animated is not provided', () => {
+    const { container } = render(
+      <ProgressBar title="Loading" value={40} status="loading" />,
+    );
+    const fill = container.querySelector('.mds-progress-bar-fill');
+    expect(fill).toHaveClass('progress-bar-striped');
+    expect(fill).not.toHaveClass('progress-bar-animated');
+  });
+
+  it('applies striped classes and animated class when loading and animated=true', () => {
+    const { container } = render(
+      <ProgressBar title="Loading" value={40} status="loading" animated />,
+    );
+    const fill = container.querySelector('.mds-progress-bar-fill');
+    expect(fill).toHaveClass('progress-bar-striped');
+    expect(fill).toHaveClass('progress-bar-animated');
+  });
+
+  it('applies striped class but not animated class when loading and animated=false', () => {
+    const { container } = render(
+      <ProgressBar
+        title="Loading"
+        value={40}
+        status="loading"
+        animated={false}
+      />,
+    );
+    const fill = container.querySelector('.mds-progress-bar-fill');
+    expect(fill).toHaveClass('progress-bar-striped');
+    expect(fill).not.toHaveClass('progress-bar-animated');
+  });
+
+  it('does not apply striped classes for non-loading statuses', () => {
+    const { container } = render(
+      <ProgressBar title="Upload" value={40} status="in-progress" />,
+    );
+    const fill = container.querySelector('.mds-progress-bar-fill');
+    expect(fill).not.toHaveClass('progress-bar-striped');
+  });
+
+  it('does not apply striped classes at 0% even when status is loading', () => {
+    const { container } = render(
+      <ProgressBar title="Loading" value={0} status="loading" />,
+    );
+    const fill = container.querySelector('.mds-progress-bar-fill');
+    expect(fill).not.toHaveClass('progress-bar-striped');
+  });
+
+  it('does not apply striped classes at 100% even when status is loading', () => {
+    const { container } = render(
+      <ProgressBar title="Loading" value={100} status="loading" />,
+    );
+    const fill = container.querySelector('.mds-progress-bar-fill');
+    expect(fill).not.toHaveClass('progress-bar-striped');
+  });
+
+  it('forwards extra props to the wrapper element', () => {
+    const { container } = render(
+      <ProgressBar title="Upload" value={50} data-testid="my-bar" />,
+    );
+    expect(container.firstChild).toHaveAttribute('data-testid', 'my-bar');
+  });
+
+  it('appends a consumer className to the wrapper', () => {
+    const { container } = render(
+      <ProgressBar title="Upload" value={50} className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('renders the fill with the correct width style', () => {
+    const { container } = render(<ProgressBar title="Upload" value={65} />);
+    const fill = container.querySelector('.mds-progress-bar-fill');
+    expect(fill).toHaveStyle({ width: '65%' });
+  });
+
+  it('updates aria-valuenow, fill width, and visual status correctly across rerenders', () => {
+    const { container, rerender } = render(
+      <ProgressBar title="Upload" value={25} status="loading" />,
+    );
+
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '25',
+    );
+    expect(container.querySelector('.mds-progress-bar-fill')).toHaveStyle({
+      width: '25%',
+    });
+    expect(container.firstChild).toHaveClass('mds-progress-bar--loading');
+
+    rerender(<ProgressBar title="Upload" value={0} status="loading" />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '0',
+    );
+    expect(container.querySelector('.mds-progress-bar-fill')).toHaveStyle({
+      width: '0%',
+    });
+    expect(container.firstChild).toHaveClass('mds-progress-bar--empty');
+    expect(container.firstChild).not.toHaveClass('mds-progress-bar--loading');
+
+    rerender(<ProgressBar title="Upload" value={60} status="warning" />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '60',
+    );
+    expect(container.querySelector('.mds-progress-bar-fill')).toHaveStyle({
+      width: '60%',
+    });
+    expect(container.firstChild).toHaveClass('mds-progress-bar--warning');
+
+    rerender(<ProgressBar title="Upload" value={100} status="error" />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '100',
+    );
+    expect(container.querySelector('.mds-progress-bar-fill')).toHaveStyle({
+      width: '100%',
+    });
+    expect(container.firstChild).toHaveClass('mds-progress-bar--completed');
+    expect(container.firstChild).not.toHaveClass('mds-progress-bar--error');
+  });
+
+  it('derives empty/completed visual states from normalized range position', () => {
+    const { container, rerender } = render(
+      <ProgressBar
+        title="Upload"
+        value={3}
+        min={3}
+        max={10}
+        status="warning"
+      />,
+    );
+
+    expect(container.firstChild).toHaveClass('mds-progress-bar--empty');
+    expect(container.firstChild).not.toHaveClass('mds-progress-bar--warning');
+
+    rerender(
+      <ProgressBar title="Upload" value={10} min={3} max={10} status="error" />,
+    );
+    expect(container.firstChild).toHaveClass('mds-progress-bar--completed');
+    expect(container.firstChild).not.toHaveClass('mds-progress-bar--error');
+  });
+
+  it.each([
+    { labelVariant: 'none' as const },
+    { labelVariant: 'inline' as const },
+    { labelVariant: 'title-and-count' as const },
+    { labelVariant: 'title' as const },
+  ])(
+    'warns when labelVariant="$labelVariant" and no accessible name is provided',
+    ({ labelVariant }) => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      render(<ProgressBar value={50} labelVariant={labelVariant} />);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('[MDS ProgressBar] No accessible name found'),
+      );
+      vi.restoreAllMocks();
+    },
+  );
+
+  it('renders correctly in RTL mode when wrapped by a dir="rtl" container', () => {
+    render(
+      <div dir="rtl">
+        <ProgressBar
+          title="جاري رفع الملفات"
+          count="٥ من ١٠"
+          value={50}
+          labelVariant="inline"
+        />
+      </div>,
+    );
+
+    expect(
+      screen.getByRole('progressbar', { name: 'جاري رفع الملفات' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('٥ من ١٠')).toBeInTheDocument();
+    expect(screen.getByText('٥ من ١٠').closest('[dir="rtl"]')).not.toBeNull();
+  });
+
+  it('renders a long translated title string without losing the accessible name', () => {
+    const longTranslatedTitle =
+      'Dies ist eine sehr lange lokalisierte Fortschrittsbeschreibung fuer den Upload mehrerer Kursmaterialien und begleitender Dateien';
+
+    render(
+      <ProgressBar
+        title={longTranslatedTitle}
+        count="5 von 10"
+        value={50}
+        labelVariant="title-and-count"
+      />,
+    );
+
+    expect(screen.getByText(longTranslatedTitle)).toBeInTheDocument();
+    expect(
+      screen.getByRole('progressbar', { name: longTranslatedTitle }),
+    ).toBeInTheDocument();
+  });
+
+  describe('ProgressBar: Fuzz Test', () => {
+    it('renders the title text without crashing for arbitrary title-and-count inputs', () => {
+      // Restrict to visible-title variants (title-and-count, title) so the getText
+      // assertion can reliably locate the rendered title span in the DOM.
+      // Restrict strings to values whose rendered text survives Testing Library's
+      // whitespace normalisation unchanged, otherwise the generic helper can fail
+      // on valid output when leading/trailing or repeated whitespace is collapsed.
+      const normalizeVisibleText = (text: string) =>
+        text.replace(/\s+/gu, ' ').trim();
+      const printableText = fc
+        .string({ unit: 'grapheme', minLength: 1, maxLength: 80 })
+        .filter(
+          (text) =>
+            normalizeVisibleText(text).length > 0 &&
+            normalizeVisibleText(text) === text,
+        );
+      fuzzComponent<ProgressBarProps>(
+        ProgressBar,
+        fc.record<ProgressBarProps>({
+          title: printableText,
+          count: printableText,
+          value: fc.integer({ min: 0, max: 100 }),
+          labelVariant: fc.constantFrom(
+            'title-and-count',
+            'title',
+          ) as fc.Arbitrary<ProgressBarProps['labelVariant']>,
+          status: fc.constantFrom(
+            'in-progress',
+            'loading',
+            'error',
+            'warning',
+          ) as fc.Arbitrary<ProgressBarProps['status']>,
+        }),
+        (props) => props.title as string,
+        { numRuns: 50 },
+      );
+    });
+  });
+});

--- a/components/progress-bar/ProgressBar.tsx
+++ b/components/progress-bar/ProgressBar.tsx
@@ -1,0 +1,197 @@
+import type { HTMLAttributes } from 'react';
+import { useId } from 'react';
+
+type ProgressBarStatus = 'in-progress' | 'loading' | 'error' | 'warning';
+
+type ProgressBarVisualStatus = 'empty' | ProgressBarStatus | 'completed';
+
+type ProgressBarLabelVariant = 'title-and-count' | 'title' | 'inline' | 'none';
+
+export interface ProgressBarProps extends HTMLAttributes<HTMLDivElement> {
+  /** Current progress value in the range defined by `min` and `max`. */
+  value?: number;
+  /** Lower bound for the progress range. Defaults to 0. */
+  min?: number;
+  /** Upper bound for the progress range. Defaults to 100. */
+  max?: number;
+  /** Visual state of the progress indicator — controls fill and track colours. */
+  status?: ProgressBarStatus;
+  /**
+   * Controls label layout:
+   * - `title-and-count`: title + count row above the bar (default)
+   * - `title`: title only above the bar
+   * - `inline`: bar with count beside it in a row
+   * - `none`: bar only, no visible label
+   */
+  labelVariant?: ProgressBarLabelVariant;
+  /** Pre-translated title text rendered above the bar (title-and-count / title variants).
+   *  Also used as the accessible name for the bar when no visible label is present. */
+  title?: string;
+  /**
+   * Pre-translated count or percentage text, e.g. "3 of 10" or "50%".
+   * The component intentionally does not calculate or format this from
+   * `value`, `min`, and `max`; word order, plural rules, and number formatting
+   * belong to the consuming application's i18n layer.
+   */
+  count?: string;
+  /** Controls striped animation when status is loading. */
+  animated?: boolean;
+}
+
+const allowedStatuses: ProgressBarStatus[] = [
+  'in-progress',
+  'loading',
+  'error',
+  'warning',
+];
+
+const allowedLabels: ProgressBarLabelVariant[] = [
+  'title-and-count',
+  'title',
+  'inline',
+  'none',
+];
+
+export const ProgressBar = ({
+  value = 0,
+  min = 0,
+  max = 100,
+  status,
+  labelVariant = 'title-and-count',
+  title,
+  count,
+  animated = false,
+  className,
+  ...props
+}: ProgressBarProps) => {
+  const titleId = useId();
+
+  const isAllowedStatus =
+    !!status && allowedStatuses.includes(status as ProgressBarStatus);
+  const isAllowedLabelVariant = allowedLabels.includes(
+    labelVariant as ProgressBarLabelVariant,
+  );
+
+  // Normalize range inputs to finite numbers and ensure an ascending range.
+  const hasFiniteRange = Number.isFinite(min) && Number.isFinite(max);
+  const hasAscendingRange = hasFiniteRange && min < max;
+  const resolvedMin = hasAscendingRange ? min : 0;
+  const resolvedMax = hasAscendingRange ? max : 100;
+  const isValueInRange = value >= resolvedMin && value <= resolvedMax;
+
+  const resolvedStatus: ProgressBarStatus = isAllowedStatus
+    ? status
+    : 'in-progress';
+  const resolvedLabel: ProgressBarLabelVariant = isAllowedLabelVariant
+    ? labelVariant
+    : 'title-and-count';
+  const clampedValue = Math.min(resolvedMax, Math.max(resolvedMin, value));
+  const fillPercent =
+    ((clampedValue - resolvedMin) / (resolvedMax - resolvedMin)) * 100;
+  // At 0% and 100% fill, visual styling is derived from normalized position,
+  // regardless of status.
+  const visualStatus: ProgressBarVisualStatus =
+    fillPercent === 0
+      ? 'empty'
+      : fillPercent === 100
+        ? 'completed'
+        : resolvedStatus;
+
+  if (import.meta.env.DEV) {
+    if (status && !isAllowedStatus) {
+      console.warn(
+        `[MDS ProgressBar] Invalid status "${status}". Falling back to "in-progress". Allowed: ${allowedStatuses.join(', ')}`,
+      );
+    }
+    if (!isAllowedLabelVariant) {
+      console.warn(
+        `[MDS ProgressBar] Invalid labelVariant "${labelVariant}". Falling back to "title-and-count". Allowed: ${allowedLabels.join(', ')}`,
+      );
+    }
+    if (!hasAscendingRange) {
+      console.warn(
+        `[MDS ProgressBar] Invalid range min="${min}" max="${max}". Falling back to min=0 and max=100 with min < max required.`,
+      );
+    }
+    if (!isValueInRange) {
+      console.warn(
+        `[MDS ProgressBar] value "${value}" is outside the allowed range [${resolvedMin}–${resolvedMax}] and will be clamped.`,
+      );
+    }
+  }
+
+  const isTitleCount = resolvedLabel === 'title-and-count';
+  const isTitle = resolvedLabel === 'title';
+  const isInline = resolvedLabel === 'inline';
+  const showTitleRow = isTitleCount || isTitle;
+
+  // Extract aria-* props so they can be forwarded to the progressbar track element,
+  // which carries role="progressbar" — the accessible element in this component.
+  const {
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
+    ...restProps
+  } = props;
+
+  // Derive accessible name for the track:
+  // - Explicit aria-labelledby wins if provided.
+  // - If a visible title element is present and no explicit aria-label, point to it.
+  const hasVisibleTitle = showTitleRow && Boolean(title);
+  const trackLabelledby =
+    ariaLabelledby ?? (hasVisibleTitle && !ariaLabel ? titleId : undefined);
+
+  // aria-label is used when no visible title is rendered (inline / none variants)
+  // and no labelledby reference applies.
+  const trackAriaLabel = ariaLabel ?? (!hasVisibleTitle ? title : undefined);
+
+  // Check derived accessible-name values regardless of the labelVariant
+  if (import.meta.env.DEV && !trackAriaLabel && !trackLabelledby) {
+    console.warn(
+      '[MDS ProgressBar] No accessible name found. Provide a title prop or aria-label / aria-labelledby.',
+    );
+  }
+
+  const wrapperClasses = [
+    'mds-progress-bar',
+    `mds-progress-bar--label-${resolvedLabel}`,
+    `mds-progress-bar--${visualStatus}`,
+  ];
+  if (className) wrapperClasses.push(className);
+
+  const fillClasses = [
+    'mds-progress-bar-fill',
+    'progress-bar',
+    // In loading status, stripes are always shown; motion is controlled by `animated`.
+    visualStatus === 'loading' ? 'progress-bar-striped' : '',
+    visualStatus === 'loading' && animated ? 'progress-bar-animated' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={wrapperClasses.join(' ')} {...restProps}>
+      {showTitleRow && (
+        <div className="mds-progress-bar-label">
+          <span id={titleId} className="mds-progress-bar-title">
+            {title}
+          </span>
+          {isTitleCount && (
+            <span className="mds-progress-bar-count">{count}</span>
+          )}
+        </div>
+      )}
+      <div
+        className="mds-progress-bar-track progress"
+        role="progressbar"
+        aria-valuenow={clampedValue}
+        aria-valuemin={resolvedMin}
+        aria-valuemax={resolvedMax}
+        aria-labelledby={trackLabelledby}
+        aria-label={trackAriaLabel}
+      >
+        <div className={fillClasses} style={{ width: `${fillPercent}%` }} />
+      </div>
+      {isInline && <span className="mds-progress-bar-count">{count}</span>}
+    </div>
+  );
+};

--- a/components/progress-bar/index.tsx
+++ b/components/progress-bar/index.tsx
@@ -1,0 +1,1 @@
+export * from './ProgressBar';

--- a/components/progress-bar/progress-bar.css
+++ b/components/progress-bar/progress-bar.css
@@ -1,0 +1,193 @@
+/* Wrapper layout */
+.mds-progress-bar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mds-spacing-xs);
+  /* 120px is intentionally has no token by design just as in Figma. */
+  min-width: 120px;
+  width: 100%;
+}
+
+/* Inline variant: bar on the left, count on the right in one row. */
+.mds-progress-bar.mds-progress-bar--label-inline {
+  flex-direction: row;
+  align-items: center;
+}
+
+/* Track (outer container) */
+.mds-progress-bar-track.progress {
+  /* Re-state Bootstrap progress primitives here so host .progress overrides cannot drift MDS visuals. */
+  /* 0.375rem = 6px from Figma; intentionally has no token by design for consumer flexibility. */
+  display: flex;
+  height: 0.375rem;
+  overflow: hidden;
+  border-radius: var(--mds-border-radius-pill);
+  background-color: var(--mds-bg-feedback-secondary-default);
+  box-shadow: none;
+}
+
+/* In-progress and loading use the primary-subtle track. */
+.mds-progress-bar--in-progress .mds-progress-bar-track,
+.mds-progress-bar--loading .mds-progress-bar-track {
+  background-color: var(--mds-bg-feedback-primary-subtle);
+}
+
+/* Error track. */
+.mds-progress-bar--error .mds-progress-bar-track {
+  background-color: var(--mds-bg-feedback-danger-subtle);
+}
+
+/* Warning track. */
+.mds-progress-bar--warning .mds-progress-bar-track {
+  background-color: var(--mds-bg-feedback-warning-subtle);
+}
+
+/* Completed and empty keep the default secondary track. */
+.mds-progress-bar--completed .mds-progress-bar-track,
+.mds-progress-bar--empty .mds-progress-bar-track {
+  background-color: var(--mds-bg-feedback-secondary-default);
+}
+
+/* Inline variant: track should fill available row space. */
+.mds-progress-bar--label-inline .mds-progress-bar-track {
+  flex: 1 1 0;
+  min-inline-size: var(--mds-spacing-xxl);
+}
+
+/* Fill (inner progress indicator) */
+.mds-progress-bar-fill.progress-bar {
+  /* Keep core progress-bar behavior local so host --bs-progress-* token changes do not leak in. */
+  display: flex;
+  overflow: hidden;
+  background-color: var(--mds-bg-interactive-primary-default);
+  transition: width 0.3s ease;
+}
+
+/* Explicit striped styles avoid dependence on host Bootstrap variables. */
+.mds-progress-bar-fill.progress-bar-striped {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
+  /* Figma loading pattern uses a larger tile than the 6px bar height. */
+  background-size: var(--mds-spacing-md) var(--mds-spacing-md);
+  background-repeat: repeat;
+  background-position-x: 0;
+}
+
+[dir='rtl'] .mds-progress-bar-fill.progress-bar-striped {
+  background-image: linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
+}
+
+.mds-progress-bar-fill.progress-bar-animated {
+  animation: mds-progress-bar-stripes 0.8s linear infinite;
+}
+
+[dir='rtl'] .mds-progress-bar-fill.progress-bar-animated {
+  animation-name: mds-progress-bar-stripes-rtl;
+}
+
+@keyframes mds-progress-bar-stripes {
+  0% {
+    background-position-x: var(--mds-spacing-md);
+  }
+}
+
+@keyframes mds-progress-bar-stripes-rtl {
+  0% {
+    background-position-x: calc(var(--mds-spacing-md) * -1);
+  }
+}
+
+/* Error fill. */
+.mds-progress-bar--error .mds-progress-bar-fill {
+  background-color: var(--mds-bg-feedback-danger-default);
+}
+
+/* Warning fill. */
+.mds-progress-bar--warning .mds-progress-bar-fill {
+  background-color: var(--mds-bg-feedback-warning-default);
+}
+
+/* Completed fill. */
+.mds-progress-bar--completed .mds-progress-bar-fill {
+  background-color: var(--mds-bg-feedback-success-default);
+}
+
+/* Empty fill blends with the track. */
+.mds-progress-bar--empty .mds-progress-bar-fill {
+  background-color: var(--mds-bg-feedback-secondary-default);
+}
+
+/* Label container */
+.mds-progress-bar-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--mds-spacing-xs);
+  width: 100%;
+
+  /* UI text/small */
+  font-family: var(--mds-font-family-base);
+  font-size: var(--mds-font-size-paragraph-small);
+  line-height: var(--mds-line-height-paragraph-small);
+  letter-spacing: var(--mds-letter-spacing-default);
+  color: var(--mds-text-subtle);
+}
+
+/* Title text */
+.mds-progress-bar-title {
+  font-weight: var(--mds-font-weight-medium);
+  line-height: var(--mds-line-height-paragraph-small);
+  word-break: break-word;
+}
+
+/* In title-and-count layout, title and count share one row and must both be able to shrink. */
+.mds-progress-bar--label-title-and-count .mds-progress-bar-title {
+  flex: 1 1 auto;
+  min-inline-size: 0;
+}
+
+/* Count / percentage text */
+.mds-progress-bar-count {
+  font-weight: var(--mds-font-weight-regular);
+
+  /* Inline count sits outside .mds-progress-bar-label, so it needs explicit text styles. */
+  font-family: var(--mds-font-family-base);
+  font-size: var(--mds-font-size-paragraph-small);
+  line-height: var(--mds-line-height-paragraph-small);
+  letter-spacing: var(--mds-letter-spacing-default);
+  color: var(--mds-text-subtle);
+  white-space: normal;
+  overflow-wrap: anywhere;
+  min-inline-size: 0;
+}
+
+/* In title-and-count layout, count is bounded to prevent hogging the row. */
+.mds-progress-bar--label-title-and-count .mds-progress-bar-count {
+  flex: 0 1 50%;
+  max-inline-size: 50%;
+  text-align: end;
+}
+
+/* In inline layout, count takes only what it needs, leaving space for the track. */
+.mds-progress-bar--label-inline .mds-progress-bar-count {
+  flex: 0 1 auto;
+  max-inline-size: 40%;
+  text-align: start;
+}


### PR DESCRIPTION
## Description

This PR introduces a new ProgressBar component with Moodle Design System token-based styling, Storybook coverage, unit tests, and Figma Code Connect mapping.

**Key implementations**

- Implemented safe runtime handling: clamps value to 0-100, falls back to invalid status/label variant to defaults, and logs dev warnings for invalid inputs.
- Added visual state override rules so 0% always renders as empty and 100% always renders as completed, regardless of status prop.
- Implemented accessibility semantics on the progress track with role progressbar, aria value attributes, and robust accessible naming via aria-labelledby or aria-label fallback.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-532

## Screenshots/Previews

<!-- Reference Chromatic visual diffs, add screenshots, or link to Storybook previews -->

## Author checklist

### File structure and exports

- [x] All 5 required files present: `ComponentName.tsx`, `component-name.css`, `ComponentName.test.tsx`, `ComponentName.stories.tsx`, `index.tsx`
- [x] `ComponentName.figma.tsx` Code Connect file created and published
- [x] Named and type exports added to `components/index.tsx`
- [x] Component stylesheet imported in `components/index.css`

### TypeScript and props

- [x] Props interface extends the correct React HTML element interface (e.g. `ButtonHTMLAttributes<HTMLButtonElement>`)
- [x] JSDoc comment on each prop
- [x] Constrained props use `allowedValues` runtime validation with a graceful fallback to a documented default
- [x] `...props` spread last on the host element

### Internationalisation

- [x] All user-facing strings accepted as props — no hardcoded text in JSX
- [x] CSS uses logical properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`) for any directional layout
- [x] RTL story added if the component has directional layout

### CSS and tokens

- [ ] All CSS values use `var(--mds-*)` tokens — no hardcoded colours, spacing, or typography
  - There lives some hardcoded values, see additional notes below
- [x] Where a matching token exists, `var(--mds-*)` is used without fallback literals (for example, `var(--mds-spacing-xs)`, not `var(--mds-spacing-xs, 0.5rem)`)

### Tests and stories

- [x] Unit tests cover: `mds-*` class on root, correct classes per variant/size, invalid prop fallback, prop forwarding, disabled state, and label rendering
- [x] Storybook stories cover all documented variants, sizes, and states
- [x] Accessibility tested — Axe WCAG AA scan runs automatically via CI on all stories tagged `test`

### Breaking changes

- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump

### AI context

- [x] Instruction files updated if this component introduces new patterns or anti-patterns

## Cross-system parity

- [x] Component name, prop names, and variant names are consistent across code, Storybook, Figma, and Zeroheight

## Additional Notes
- The height and min-width of the track line intentionally have no tokens (confirmed by the designers) to provide flexibility