### PR TITLE
fix(Badge): Remove accidental import of css within component file

### DIFF
--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -1,6 +1,5 @@
 import type { HTMLAttributes, ReactElement } from 'react';
 import { isValidElement } from 'react';
-import './badge.css';
 
 type BadgeVariant =
   | 'primary'


### PR DESCRIPTION
## Description

Remove accidental import of css within component file, this causes collision of filename during the built, hence causing unwanted incremental filename `Badge2.js`

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-595

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews
<img width="263" height="199" alt="Screenshot 2026-06-04 at 1 58 24 pm" src="https://github.com/user-attachments/assets/350801de-9d15-4e00-91d5-55747043b569" />

## Checklist

- [ ] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [ ] I have considered accessibility and described any improvements or issues
- [ ] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

N/A
