### PR TITLE
feat(Components)!: Entrypoint for the component-only styling assets

### DIFF
--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -1,3 +1,1 @@
-// CSS is aggregated via components/index.css and imported by the package root entry (index.ts).
-// It is intentionally omitted here so per-component subpath imports remain side-effect-free for JS consumers.
 export * from './Button';

--- a/components/radio/index.tsx
+++ b/components/radio/index.tsx
@@ -1,3 +1,1 @@
-// CSS is aggregated via components/index.css and imported by the package root entry (index.ts).
-// It is intentionally omitted here so per-component subpath imports remain side-effect-free for JS consumers.
 export * from './Radio';

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "The Moodle Design System",
   "files": [
     "/dist",
-    "/tokens/css",
-    "/tokens/scss",
     "/css.d.ts"
   ],
   "exports": {
@@ -17,18 +15,27 @@
       "types": "./css.d.ts",
       "default": "./dist/index.css"
     },
+    "./components/css": {
+      "default": "./dist/components/index.css"
+    },
+    "./components/scss/legacy": {
+      "default": "./dist/components/_index.legacy.scss"
+    },
     "./components/*": {
       "types": "./dist/components/*/index.d.ts",
       "import": "./dist/components/*/index.js"
     },
+    "./components/*/css": {
+      "default": "./dist/components/*/index.css"
+    },
     "./tokens/css": {
-      "default": "./tokens/css/index.css"
+      "default": "./dist/tokens/css/index.css"
     },
     "./tokens/scss": {
-      "default": "./tokens/scss/_index.scss"
+      "default": "./dist/tokens/scss/_index.scss"
     },
     "./tokens/scss/legacy": {
-      "default": "./tokens/scss/_index.legacy.scss"
+      "default": "./dist/tokens/scss/_index.legacy.scss"
     }
   },
   "type": "module",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import { playwright } from '@vitest/browser-playwright';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { PluginContext } from 'rollup';
 const dirname =
   typeof __dirname !== 'undefined'
     ? __dirname
@@ -26,9 +27,125 @@ const componentEntries = Object.fromEntries(
     ]),
 );
 
+interface ComponentCssAsset {
+  componentName: string;
+  source: string;
+}
+
+function getComponentCssAssets(): ComponentCssAsset[] {
+  const componentsIndexPath = path.join(dirname, 'components', 'index.css');
+  const indexCss = fs.readFileSync(componentsIndexPath, 'utf8');
+
+  const importRegex = /@import\s+['"](.+?)['"];?/g;
+  const assets: ComponentCssAsset[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = importRegex.exec(indexCss)) !== null) {
+    const relativeImportPath = match[1];
+    const absoluteImportPath = path.resolve(
+      path.dirname(componentsIndexPath),
+      relativeImportPath,
+    );
+
+    const componentName = path.posix
+      .normalize(path.dirname(relativeImportPath))
+      .replace(/^\.\//, '');
+
+    assets.push({
+      componentName,
+      source: fs.readFileSync(absoluteImportPath, 'utf8').trim(),
+    });
+  }
+
+  return assets;
+}
+
+function buildComponentsCssManifest(assets: ComponentCssAsset[]): string {
+  const imports = assets.map(
+    (asset) => `@import './${asset.componentName}/index.css';`,
+  );
+
+  return `${imports.join('\n')}\n`;
+}
+
+function buildComponentsLegacyScssManifest(
+  assets: ComponentCssAsset[],
+): string {
+  const sections = assets.map(
+    (asset) => `/* ${asset.componentName}/index.css */\n${asset.source}`,
+  );
+
+  return `${sections.join('\n\n')}\n`;
+}
+
+function emitComponentAssets(ctx: PluginContext): void {
+  const assets = getComponentCssAssets();
+  const componentsManifest = buildComponentsCssManifest(assets);
+  const legacyComponentsManifest = buildComponentsLegacyScssManifest(assets);
+
+  // Component aggregate manifests
+  ctx.emitFile({
+    type: 'asset',
+    fileName: 'components/index.css',
+    source: componentsManifest,
+  });
+
+  // Legacy Sass entrypoint: monolithic inlineable stylesheet for consumers that
+  // compile Sass with legacy import behavior.
+  ctx.emitFile({
+    type: 'asset',
+    fileName: 'components/_index.legacy.scss',
+    source: legacyComponentsManifest,
+  });
+
+  // Per-component CSS files
+  for (const componentAsset of assets) {
+    ctx.emitFile({
+      type: 'asset',
+      fileName: `components/${componentAsset.componentName}/index.css`,
+      source: `${componentAsset.source}\n`,
+    });
+  }
+}
+
+function emitTokenAssets(ctx: PluginContext): void {
+  const tokensCssDir = path.join(dirname, 'tokens', 'css');
+  const tokensScssDir = path.join(dirname, 'tokens', 'scss');
+
+  // Emit every file in tokens/css/ into dist/tokens/css/
+  for (const file of fs.readdirSync(tokensCssDir)) {
+    ctx.emitFile({
+      type: 'asset',
+      fileName: `tokens/css/${file}`,
+      source: fs.readFileSync(path.join(tokensCssDir, file), 'utf8'),
+    });
+  }
+
+  // Emit every file in tokens/scss/ into dist/tokens/scss/
+  for (const file of fs.readdirSync(tokensScssDir)) {
+    ctx.emitFile({
+      type: 'asset',
+      fileName: `tokens/scss/${file}`,
+      source: fs.readFileSync(path.join(tokensScssDir, file), 'utf8'),
+    });
+  }
+}
+
+function emitCssAssets() {
+  return {
+    name: 'emit-css-assets',
+    apply: 'build' as const,
+    generateBundle() {
+      emitComponentAssets(this);
+      emitTokenAssets(this);
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
     react(),
+    emitCssAssets(),
     dts({
       // Exclude dev-only files from the generated type declarations, matching tsconfig.json.
       exclude: ['**/*.stories.tsx', '**/*.test.tsx', '**/*.figma.tsx'],
@@ -49,11 +166,11 @@ export default defineConfig({
       fileName: (_, entryName) => `${entryName}.js`, // Preserve entry path as output filename.
       formats: ['es'], // Specifies the output format (ES modules only).
     },
-    cssCodeSplit: false, // bundle all CSS into a single file
+    cssCodeSplit: false, // Bundle all CSS into a single inlined dist/index.css for full-build direct URL loading.
     rollupOptions: {
       external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime'],
       output: {
-        assetFileNames: 'index.css', // name the CSS file
+        assetFileNames: 'index.css', // Name the full-build inlined CSS bundle.
         // Transpile every source file into its own output file with a stable, predictable
         // path — no chunk splitting, no content hashes. This matches Moodle's loading model
         // where files are served directly by URL without a consumer-side build step.


### PR DESCRIPTION
## Description

This PR adds granular component styling entrypoints while keeping the existing full-build CSS behavior unchanged.

- Introduces component-only CSS and SCSS entrypoints, giving consumers finer control over which styles/assets they load (free from Bootstrap)
- Introduces per-component subpath imports, enabling consumers to import only what they use for better performance
- Preserving the existing`/dist/index.css` as the full-build CSS (Bootstrap + tokens + components) contract to load assets directly by URL
 
**BREAKING CHANGE:**
- Moves the published `/tokens` to `/dist/tokens`, ensuring all published artifacts are sourced from a single, consistent distribution boundary.

### How
A custom Vite generateBundle plugin emits styling assets during build.

The plugin:
- Emits `/dist/components/index.css` as an import manifest of components-only CSS files
- Emits `/dist/components/index.scss` as the same manifest for SCSS consumption
- Emits `/dist/components/<component>/index.css` files for each referenced component
- Emits token CSS/SCSS files into dist/tokens

Build behavior for the full bundle is intentionally unchanged:
- `cssCodeSplit` remains `false`
- The main CSS output remains one full inlined `/dist/index.css` bundle

### Package exports
New exports:
- `@moodlehq/design-system/components/css` → `/dist/components/index.css` (components-only)
- `@moodlehq/design-system/components/scss` → `/dist/components/index.scss` (components-only)

Updated token exports:
- `@moodlehq/design-system/tokens/css` → `/dist/tokens/index.css` (tokens-only)
- `@moodlehq/design-system/tokens/scss` → `/dist/tokens/_index.scss` (tokens-only)
- `@moodlehq/design-system/tokens/scss/legacy` → `/dist/tokens/_index.legacy.scss` (tokens-only)

Unchanged:
- `@moodlehq/design-system/css` → `/dist/index.css` (full bundle = Bootstrap + tokens + components)
- Component JS subpath exports remain JS/TS entrypoints only without CSS

### Why this approach
- Keeps the existing full-build contract safe for direct URL loading
- Avoids Bootstrap/token dependency-order issues that can happen with CSS splitting
- Adds component-only styling options without breaking existing consumers
- Keeps published package contents consistent under dist for clearer distribution boundaries

## Related Jira or GitHub Issue

Main task to enable component styling in LMS: https://moodle.atlassian.net/browse/MDS-595

Related tasks:
- CSS to SCSS support: https://moodle.atlassian.net/browse/MDS-594
- Entrypoint that has no Bootstrap: https://moodle.atlassian.net/browse/MDS-518

## Type of Change

- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

<img width="210" height="508" alt="Screenshot 2026-06-12 at 5 03 44 pm" src="https://github.com/user-attachments/assets/dfe56492-cdee-4f4d-a8d9-3768282b7b1c" />

## Checklist

- [ ] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [ ] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

N/A
