### PR TITLE
feat(Link): Add new link component

### DIFF
--- a/components/index.css
+++ b/components/index.css
@@ -3,6 +3,7 @@
 @import './button/button.css';
 @import './checkbox/checkbox.css';
 @import './close-button/close-button.css';
+@import './link/link.css';
 @import './pagination/pagination.css';
 @import './progress-bar/progress-bar.css';
 @import './radio/radio.css';

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -13,6 +13,9 @@ export type { CheckboxProps } from './checkbox';
 export { CloseButton } from './close-button';
 export type { CloseButtonProps } from './close-button';
 
+export { Link } from './link';
+export type { LinkProps } from './link';
+
 export { Pagination } from './pagination';
 export type { PaginationProps } from './pagination';
 

--- a/components/link/Link.figma.tsx
+++ b/components/link/Link.figma.tsx
@@ -1,0 +1,79 @@
+import figma from '@figma/code-connect';
+import { Link } from './Link';
+
+const url =
+  'https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=10843-763';
+
+const variant = figma.enum('Variant', {
+  Primary: 'primary',
+  Secondary: 'secondary',
+});
+
+const linkLabel = 'Label';
+const linkHref = '#';
+
+figma.connect(Link, url, {
+  variant: { State: 'default', Link: 'none' },
+  props: { variant: variant },
+  example: ({ variant }) => (
+    <Link label={linkLabel} href={linkHref} variant={variant} />
+  ),
+});
+
+figma.connect(Link, url, {
+  variant: { State: 'hover', Link: 'none' },
+  props: { variant: variant },
+  example: ({ variant }) => (
+    <Link label={linkLabel} href={linkHref} variant={variant} />
+  ),
+});
+
+figma.connect(Link, url, {
+  variant: { State: 'pressed', Link: 'none' },
+  props: { variant: variant },
+  example: ({ variant }) => (
+    <Link label={linkLabel} href={linkHref} variant={variant} />
+  ),
+});
+
+figma.connect(Link, url, {
+  variant: { State: 'focus', Link: 'none' },
+  props: { variant: variant },
+  example: ({ variant }) => (
+    <Link label={linkLabel} href={linkHref} variant={variant} />
+  ),
+});
+
+figma.connect(Link, url, {
+  variant: { State: 'disabled', Link: 'none' },
+  props: { variant: variant },
+  example: ({ variant }) => (
+    <Link label={linkLabel} href={linkHref} variant={variant} disabled />
+  ),
+});
+
+figma.connect(Link, url, {
+  variant: { State: 'default', Link: 'startIcon' },
+  props: { variant: variant },
+  example: ({ variant }) => (
+    <Link
+      label={linkLabel}
+      href={linkHref}
+      variant={variant}
+      startIcon={<i className="fa-solid fa-arrow-left" />}
+    />
+  ),
+});
+
+figma.connect(Link, url, {
+  variant: { State: 'default', Link: 'endIcon' },
+  props: { variant: variant },
+  example: ({ variant }) => (
+    <Link
+      label={linkLabel}
+      href={linkHref}
+      variant={variant}
+      endIcon={<i className="fa-solid fa-arrow-right" />}
+    />
+  ),
+});

--- a/components/link/Link.stories.tsx
+++ b/components/link/Link.stories.tsx
@@ -1,0 +1,292 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fireEvent, fn } from 'storybook/test';
+import { Link } from './Link';
+
+const iconMapping = {
+  None: undefined,
+  'Arrow Left': <i className="fa-solid fa-arrow-left" aria-hidden="true" />,
+  'Arrow Right': <i className="fa-solid fa-arrow-right" aria-hidden="true" />,
+};
+
+const meta = {
+  title: 'Components/Link',
+  component: Link,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs', 'test', 'stable'],
+  argTypes: {
+    label: {
+      description: 'Visible link label.',
+      table: {
+        defaultValue: { summary: '' },
+      },
+    },
+    href: {
+      control: { type: 'text' },
+      description: 'Native anchor href.',
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary'],
+      description: 'Link visual variant.',
+      table: {
+        type: { summary: 'primary | secondary' },
+        defaultValue: { summary: 'primary' },
+      },
+    },
+    startIcon: {
+      description:
+        'Icon rendered before the label. Accepts only intrinsic `<i>` or `<svg>` elements.',
+      options: Object.keys(iconMapping),
+      mapping: iconMapping,
+      control: { type: 'select' },
+    },
+    endIcon: {
+      description:
+        'Icon rendered after the label. Accepts only intrinsic `<i>` or `<svg>` elements.',
+      options: Object.keys(iconMapping),
+      mapping: iconMapping,
+      control: { type: 'select' },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disables interaction and removes the href target.',
+      table: {
+        type: { summary: 'true | false' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    target: {
+      control: { type: 'select' },
+      options: ['_self', '_blank', '_parent', '_top'],
+      description:
+        'Browsing context for the link. When set to `_blank` the component automatically adds `rel="noopener noreferrer"` to prevent reverse tabnabbing.',
+      table: {
+        type: { summary: '_self | _blank | _parent | _top' },
+        defaultValue: { summary: '_self' },
+      },
+    },
+    rel: {
+      control: { type: 'text' },
+      description:
+        'Space-separated list of link relationship tokens (e.g. `noopener noreferrer`). When `target="_blank"` is set, `noopener` and `noreferrer` are always merged in automatically.',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    onClick: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    label: 'Link',
+    href: '#storybook-link',
+    variant: undefined,
+    disabled: false,
+  },
+} satisfies Meta<typeof Link>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    // Prevent the anchor from navigating during Storybook/Playwright tests.
+    // Without preventDefault the browser connection closes mid-play and the
+    // test runner reports a false "page closed unexpectedly" error.
+    onClick: fn((e: React.MouseEvent<HTMLAnchorElement>) => e.preventDefault()),
+  },
+  play: async ({ canvas, args, userEvent }) => {
+    const link = canvas.getByRole('link', { name: args.label });
+    await userEvent.click(link);
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const Variants: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: { canvas: { sourceState: 'none' } },
+  },
+  render: () => (
+    <div style={{ display: 'flex', gap: 'var(--mds-spacing-xl)' }}>
+      <Link label="Primary" href="#storybook-link" />
+      <Link label="Secondary" href="#storybook-link" variant="secondary" />
+    </div>
+  ),
+};
+
+export const WithIcons: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: { canvas: { sourceState: 'none' } },
+  },
+  render: () => (
+    <div style={{ display: 'flex', gap: 'var(--mds-spacing-xl)' }}>
+      <Link
+        label="Start icon"
+        href="#storybook-link"
+        startIcon={iconMapping['Arrow Left']}
+      />
+      <Link
+        label="End icon"
+        href="#storybook-link"
+        endIcon={iconMapping['Arrow Right']}
+      />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    onClick: fn(),
+  },
+  play: async ({ canvas, args }) => {
+    const link = canvas.getByRole('link', { name: args.label });
+    // The disabled link has `pointer-events: none` so pointer simulation is
+    // blocked by Playwright. Use fireEvent to dispatch the DOM event directly
+    // and verify the component's JS guard (stopPropagation + early return)
+    // prevents onClick from being called.
+    fireEvent.click(link);
+    await expect(args.onClick).not.toHaveBeenCalled();
+    await expect(link).toHaveAttribute('aria-disabled', 'true');
+  },
+};
+
+// In RTL layouts directional icons mirror: arrow-right points toward the
+// logical start in a right-to-left reading context.
+export const RightToLeft: Story = {
+  args: {
+    label: 'پیوند',
+    startIcon: iconMapping['Arrow Right'],
+  },
+  decorators: [
+    (Story) => (
+      <div dir="rtl">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['test', 'stable'],
+};
+
+// ─── State matrix ────────────────────────────────────────────────────────────
+
+const matrixGridStyle = {
+  display: 'grid' as const,
+  gap: 'var(--mds-spacing-xs)',
+  gridTemplateColumns:
+    'minmax(7rem, auto) minmax(8rem, auto) repeat(5, minmax(7rem, auto))',
+  alignItems: 'center' as const,
+};
+
+const matrixLabelCellStyle = {
+  color: 'var(--mds-text-subtle)',
+  fontSize: 'var(--mds-font-size-paragraph-small)',
+  fontFamily: 'var(--mds-font-family-base)',
+  fontWeight: 'var(--mds-font-weight-medium)',
+};
+
+const matrixStateCellStyle = {
+  minHeight: '2rem',
+  display: 'inline-flex' as const,
+  alignItems: 'center' as const,
+  justifyContent: 'flex-start' as const,
+};
+
+const linkMatrixVariants = [
+  { label: 'Primary', variant: 'primary' as const },
+  { label: 'Secondary', variant: 'secondary' as const },
+];
+
+const linkMatrixUsages = [
+  { label: 'No icon', startIcon: undefined, endIcon: undefined },
+  {
+    label: 'Start icon',
+    startIcon: iconMapping['Arrow Left'],
+    endIcon: undefined,
+  },
+  {
+    label: 'End icon',
+    startIcon: undefined,
+    endIcon: iconMapping['Arrow Right'],
+  },
+];
+
+const linkMatrixStates = [
+  { key: 'default', label: 'Default' },
+  { key: 'hover', label: 'Hover' },
+  { key: 'pressed', label: 'Pressed' },
+  { key: 'focus-visible', label: 'Focus visible' },
+  { key: 'disabled', label: 'Disabled' },
+] as const;
+
+export const StateMatrix: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      canvas: { sourceState: 'none' },
+      description: {
+        story:
+          'State matrix for visual regression review across variant and icon usage combinations. Hover, pressed, and focus-visible cells are driven by the Storybook pseudo-states addon.',
+      },
+    },
+    // Pseudo-states addon selectors target the <a> anchor rendered by Link.
+    pseudo: {
+      hover: "[data-matrix-state='hover'] a",
+      active: "[data-matrix-state='pressed'] a",
+      focusVisible: "[data-matrix-state='focus-visible'] a",
+    },
+  },
+  render: () => (
+    <div style={{ display: 'grid', gap: 'var(--mds-spacing-xs)' }}>
+      {/* Header row */}
+      <div style={matrixGridStyle}>
+        <span style={matrixLabelCellStyle}>Variant</span>
+        <span style={matrixLabelCellStyle}>Icon usage</span>
+        {linkMatrixStates.map((state) => (
+          <span key={state.key} style={matrixLabelCellStyle}>
+            {state.label}
+          </span>
+        ))}
+      </div>
+
+      {/* Data rows: variant × icon usage */}
+      {linkMatrixVariants.flatMap((variantDef) =>
+        linkMatrixUsages.map((usage) => (
+          <div
+            key={`${variantDef.variant}-${usage.label}`}
+            style={matrixGridStyle}
+          >
+            <span style={matrixLabelCellStyle}>{variantDef.label}</span>
+            <span style={matrixLabelCellStyle}>{usage.label}</span>
+            {linkMatrixStates.map((state) => {
+              const isDisabled = state.key === 'disabled';
+              return (
+                <div
+                  key={state.key}
+                  data-matrix-state={state.key}
+                  style={matrixStateCellStyle}
+                >
+                  <Link
+                    label="Link"
+                    href="#storybook-link"
+                    variant={variantDef.variant}
+                    startIcon={usage.startIcon}
+                    endIcon={usage.endIcon}
+                    disabled={isDisabled}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        )),
+      )}
+    </div>
+  ),
+};

--- a/components/link/Link.test.tsx
+++ b/components/link/Link.test.tsx
@@ -1,0 +1,214 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Link } from './Link';
+
+describe('Link: Unit Test', () => {
+  describe('rendering', () => {
+    it('applies the mds-link class name', () => {
+      render(<Link label="Link" href="#docs" />);
+      expect(screen.getByRole('link')).toHaveClass('mds-link');
+    });
+
+    it('renders the label correctly', () => {
+      render(<Link label="Read docs" href="#docs" />);
+      expect(screen.getByRole('link')).toHaveTextContent('Read docs');
+    });
+
+    it('renders the selected variant class', () => {
+      render(<Link label="Subtle link" href="#docs" variant="secondary" />);
+      expect(screen.getByRole('link')).toHaveClass('mds-link--secondary');
+    });
+
+    it('falls back to primary and warns in development for an invalid variant', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      render(<Link label="Link" href="#docs" variant="invalid" />);
+
+      expect(screen.getByRole('link')).toHaveClass('mds-link--primary');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[MDS Link] Invalid variant "invalid"'),
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('icons', () => {
+    it('renders a start icon when provided', () => {
+      render(
+        <Link
+          label="Back"
+          href="#docs"
+          startIcon={<i data-testid="start-icon" aria-hidden="true" />}
+        />,
+      );
+
+      expect(screen.getByTestId('start-icon')).toBeInTheDocument();
+    });
+
+    it('renders an end icon when provided', () => {
+      render(
+        <Link
+          label="Next"
+          href="#docs"
+          endIcon={<i data-testid="end-icon" aria-hidden="true" />}
+        />,
+      );
+
+      expect(screen.getByTestId('end-icon')).toBeInTheDocument();
+    });
+
+    it('renders only the start icon and warns when both icons are passed', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      render(
+        <Link
+          label="Link"
+          href="#docs"
+          startIcon={<i data-testid="start-icon" aria-hidden="true" />}
+          endIcon={
+            <svg data-testid="end-icon" aria-hidden="true" viewBox="0 0 1 1" />
+          }
+        />,
+      );
+
+      expect(screen.getByTestId('start-icon')).toBeInTheDocument();
+      expect(screen.queryByTestId('end-icon')).not.toBeInTheDocument();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Link: pass either startIcon or endIcon, not both. Rendering startIcon only.',
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('logs a console.error and drops non-<i>/<svg> elements passed as icons at runtime', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      render(
+        <Link
+          label="Link"
+          href="#docs"
+          startIcon={
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (<span data-testid="bad-start-icon" />) as any
+          }
+          endIcon={
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (<div data-testid="bad-end-icon" />) as any
+          }
+        />,
+      );
+
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(screen.queryByTestId('bad-start-icon')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('bad-end-icon')).not.toBeInTheDocument();
+
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('applies disabled accessibility and interaction attributes', () => {
+      render(<Link label="Disabled" href="#docs" disabled />);
+
+      const link = screen.getByRole('link', { name: 'Disabled' });
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+      expect(link).toHaveAttribute('tabindex', '-1');
+      expect(link).not.toHaveAttribute('href');
+      expect(link).toHaveClass('mds-link--disabled');
+    });
+
+    it('prevents click handlers from firing when disabled', () => {
+      const onClick = vi.fn();
+      render(<Link label="Disabled" href="#docs" disabled onClick={onClick} />);
+
+      fireEvent.click(screen.getByRole('link', { name: 'Disabled' }));
+
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('component aria-disabled is not overridden by a consumer-passed prop', () => {
+      // Spread order: {...props} comes before our computed aria-disabled so
+      // the component's controlled value always wins.
+      render(
+        <Link
+          label="Disabled"
+          href="#docs"
+          disabled
+          aria-disabled={false as unknown as boolean}
+        />,
+      );
+
+      expect(screen.getByRole('link', { name: 'Disabled' })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+    });
+  });
+
+  describe('HTML attributes', () => {
+    it('forwards the href and extra props to the anchor element', () => {
+      render(<Link label="Docs" href="#docs" data-testid="docs-link" />);
+
+      const link = screen.getByTestId('docs-link');
+      expect(link).toHaveAttribute('href', '#docs');
+    });
+
+    it('auto-adds noopener noreferrer when target="_blank" is given without rel', () => {
+      render(
+        <Link
+          label="Docs"
+          href="#docs"
+          data-testid="docs-link"
+          target="_blank"
+        />,
+      );
+
+      const link = screen.getByTestId('docs-link');
+      expect(link).toHaveAttribute('target', '_blank');
+      const rel = link.getAttribute('rel') ?? '';
+      expect(rel).toContain('noopener');
+      expect(rel).toContain('noreferrer');
+    });
+
+    it('merges existing rel tokens with noopener noreferrer when target="_blank"', () => {
+      render(
+        <Link
+          label="Docs"
+          href="#docs"
+          data-testid="docs-link"
+          target="_blank"
+          rel="noreferrer"
+        />,
+      );
+
+      const link = screen.getByTestId('docs-link');
+      const rel = link.getAttribute('rel') ?? '';
+      // noreferrer was already present; noopener must be added; no duplicates
+      expect(rel.split(/\s+/)).toContain('noopener');
+      expect(rel.split(/\s+/)).toContain('noreferrer');
+      expect(rel.split(/\s+/).filter((t) => t === 'noreferrer')).toHaveLength(
+        1,
+      );
+    });
+
+    it('does not force rel when target is not "_blank"', () => {
+      render(
+        <Link
+          label="Docs"
+          href="#docs"
+          data-testid="docs-link"
+          target="_self"
+        />,
+      );
+
+      expect(screen.getByTestId('docs-link')).not.toHaveAttribute('rel');
+    });
+
+    it('forwards ref to the anchor element', () => {
+      const ref = { current: null as HTMLAnchorElement | null };
+      render(<Link label="Docs" href="#docs" ref={ref} />);
+      expect(ref.current).toBe(screen.getByRole('link', { name: 'Docs' }));
+    });
+  });
+});

--- a/components/link/Link.tsx
+++ b/components/link/Link.tsx
@@ -1,0 +1,137 @@
+import type { AnchorHTMLAttributes, MouseEvent, ReactElement } from 'react';
+import { forwardRef, isValidElement } from 'react';
+
+type LinkVariant = 'primary' | 'secondary';
+
+type IconElement = ReactElement<'i' | 'svg'>;
+
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  label: string;
+  variant?: string;
+  disabled?: boolean;
+  startIcon?: IconElement;
+  endIcon?: IconElement;
+}
+
+const allowedVariants: LinkVariant[] = ['primary', 'secondary'];
+
+const isIconElement = (el: unknown, propName: string): el is IconElement => {
+  const valid = isValidElement(el) && (el.type === 'i' || el.type === 'svg');
+  if (!valid && el != null && import.meta.env.DEV) {
+    console.error(`Link: \`${propName}\` must be an <i> or <svg> element.`);
+  }
+  return valid;
+};
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  {
+    label,
+    variant,
+    disabled = false,
+    startIcon,
+    endIcon,
+    className,
+    href,
+    target,
+    rel,
+    onClick,
+    tabIndex,
+    role,
+    ...props
+  },
+  ref,
+) {
+  const resolvedVariant =
+    variant && allowedVariants.includes(variant as LinkVariant)
+      ? (variant as LinkVariant)
+      : 'primary';
+  const resolvedStartIcon = isIconElement(startIcon, 'startIcon')
+    ? startIcon
+    : null;
+  const resolvedEndIcon = isIconElement(endIcon, 'endIcon') ? endIcon : null;
+
+  if (import.meta.env.DEV) {
+    const hasAccessibleName =
+      label.trim().length > 0 ||
+      Boolean(props['aria-label']?.trim()) ||
+      Boolean(props['aria-labelledby']?.trim());
+
+    if (!hasAccessibleName) {
+      console.warn(
+        'Link: provide a label, aria-label, or aria-labelledby for accessibility.',
+      );
+    }
+
+    if (variant && !allowedVariants.includes(variant as LinkVariant)) {
+      console.warn(
+        `[MDS Link] Invalid variant "${variant}". Falling back to "primary". Allowed: ${allowedVariants.join(', ')}`,
+      );
+    }
+
+    if (resolvedStartIcon && resolvedEndIcon) {
+      console.warn(
+        'Link: pass either startIcon or endIcon, not both. Rendering startIcon only.',
+      );
+    }
+  }
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    // Anchors have no native disabled state, so block activation explicitly.
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onClick?.(event);
+  };
+
+  // When opening in a new tab, ensure the page can't access window.opener
+  // and browsers don't send the Referer header (reverse tabnabbing protection).
+  const resolvedRel = (() => {
+    if (target !== '_blank') return rel;
+    const parts = new Set([
+      ...(rel ?? '').split(/\s+/).filter(Boolean),
+      'noopener',
+      'noreferrer',
+    ]);
+    return Array.from(parts).join(' ');
+  })();
+
+  const classes = ['mds-link', `mds-link--${resolvedVariant}`];
+  if (disabled) {
+    classes.push('mds-link--disabled');
+  }
+  if (className) {
+    classes.push(className);
+  }
+
+  return (
+    <a
+      ref={ref}
+      {...props}
+      className={classes.join(' ')}
+      href={disabled ? undefined : href}
+      target={target}
+      rel={resolvedRel}
+      aria-disabled={disabled || undefined}
+      tabIndex={disabled ? -1 : tabIndex}
+      role={disabled ? (role ?? 'link') : role}
+      onClick={handleClick}
+    >
+      {resolvedStartIcon ? (
+        <span className="mds-link__icon" aria-hidden="true">
+          {resolvedStartIcon}
+        </span>
+      ) : null}
+      <span className="mds-link__label">{label}</span>
+      {resolvedStartIcon ? null : resolvedEndIcon ? (
+        <span className="mds-link__icon" aria-hidden="true">
+          {resolvedEndIcon}
+        </span>
+      ) : null}
+    </a>
+  );
+});
+
+Link.displayName = 'Link';

--- a/components/link/index.tsx
+++ b/components/link/index.tsx
@@ -1,0 +1,2 @@
+// It is intentionally omitted here so per-component subpath imports remain side-effect-free for JS consumers.
+export * from './Link';

--- a/components/link/link.css
+++ b/components/link/link.css
@@ -1,0 +1,122 @@
+.mds-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mds-spacing-xs);
+
+  color: var(--mds-text-link-primary-default);
+  font-family: var(--mds-font-family-base);
+  font-weight: var(--mds-font-weight-regular);
+  font-size: var(--mds-font-size-paragraph-default);
+  line-height: var(--mds-line-height-paragraph-xs);
+  letter-spacing: var(--mds-letter-spacing-default);
+  text-decoration: none;
+
+  cursor: pointer;
+}
+
+.mds-link:hover:not(:focus-visible) {
+  color: var(--mds-text-link-primary-hover);
+}
+
+.mds-link:active {
+  color: var(--mds-text-link-primary-hover);
+}
+
+/* Underline on hover applies only to the label text, not the icon.
+   Pressed state has no underline (Figma). Thickness and position use
+   from-font so the underline follows the font's own metrics. */
+.mds-link:hover:not(:focus-visible) .mds-link__label {
+  text-decoration: underline;
+  text-decoration-thickness: from-font;
+  text-underline-position: from-font;
+}
+
+/* Slide icon toward the label on hover using transform so the link node width
+   stays constant (gap remains --mds-spacing-xs; only the icon moves visually). */
+.mds-link:hover:not(:focus-visible) .mds-link__icon:first-child {
+  transform: translateX(var(--mds-spacing-xxs));
+}
+
+.mds-link:hover:not(:focus-visible) .mds-link__icon:last-child {
+  transform: translateX(calc(-1 * var(--mds-spacing-xxs)));
+}
+
+[dir='rtl'] .mds-link:hover:not(:focus-visible) .mds-link__icon:first-child {
+  transform: translateX(calc(-1 * var(--mds-spacing-xxs)));
+}
+
+[dir='rtl'] .mds-link:hover:not(:focus-visible) .mds-link__icon:last-child {
+  transform: translateX(var(--mds-spacing-xxs));
+}
+
+/* Reset icon position on press */
+.mds-link:active .mds-link__icon {
+  transform: none;
+}
+
+.mds-link:focus {
+  outline: none;
+}
+
+.mds-link:focus-visible {
+  /* Bottom-only focus underline matching Figma: 2px border-bottom, 1px gap below content */
+  outline: none;
+  border-radius: 0;
+  padding-bottom: var(--mds-spacing-offset);
+  border-bottom: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
+}
+
+.mds-link.mds-link--secondary {
+  color: var(--mds-text-subtle);
+}
+
+.mds-link.mds-link--secondary:hover:not(:focus-visible),
+.mds-link.mds-link--secondary:active {
+  color: var(--mds-text-default);
+}
+
+.mds-link.mds-link--disabled,
+.mds-link.mds-link--disabled:hover,
+.mds-link.mds-link--disabled:active {
+  color: var(--mds-text-link-primary-disabled);
+  pointer-events: none;
+}
+
+.mds-link.mds-link--disabled .mds-link__icon,
+.mds-link.mds-link--disabled:hover .mds-link__icon,
+.mds-link.mds-link--disabled:active .mds-link__icon {
+  transform: none;
+}
+
+.mds-link.mds-link--disabled .mds-link__label,
+.mds-link.mds-link--disabled:hover .mds-link__label,
+.mds-link.mds-link--disabled:active .mds-link__label {
+  text-decoration: none;
+}
+
+.mds-link.mds-link--secondary.mds-link--disabled,
+.mds-link.mds-link--secondary.mds-link--disabled:hover,
+.mds-link.mds-link--secondary.mds-link--disabled:active {
+  color: var(--mds-text-muted);
+}
+
+.mds-link__icon,
+.mds-link__icon i,
+.mds-link__icon svg {
+  inline-size: var(--mds-icons-xs);
+  block-size: var(--mds-icons-xs);
+  font-size: var(--mds-icons-xs);
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.mds-link__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 150ms ease;
+}
+
+.mds-link__label {
+  text-align: start;
+}


### PR DESCRIPTION
## Description

Adds the `Link` component to the Moodle Design System.

The component renders a native `<a>` anchor element styled with `--mds-*` tokens and Bootstrap-compatible class hooks. It supports two visual variants (`primary` and `secondary`), optional prefix/suffix icons, a disabled state, RTL layout, and keyboard focus.

Key implementation decisions:

- **No children** — label text is always passed as a named `label` prop, keeping the API explicit and i18n-safe.
- **Icon guard** — `startIcon` and `endIcon` accept only intrinsic `<i>` or `<svg>` elements. Invalid elements are dropped at runtime with a `console.error` in development, preventing arbitrary content from leaking into the icon slot.
- **Single icon rule** — if both `startIcon` and `endIcon` are provided the component renders only `startIcon` and emits a `console.warn`.
- **Disabled state** — anchors have no native disabled attribute. The component removes `href`, sets `aria-disabled="true"`, sets `tabIndex={-1}`, and blocks `onClick` via `event.preventDefault()` / `event.stopPropagation()`.
- **Focus ring** — uses a bottom-only `border-bottom` underline approach to match the Figma spec, which differs from the standard `outline` ring pattern used on other interactive components. `outline: none` is set on `:focus`, and the underline is applied on `:focus-visible`.
- **Icon animation** — prefix/suffix icons translate toward the label text on hover using `transform: translateX()` with logical-property-aware RTL reversals, so the link's layout width stays constant.
- **`forwardRef`** — the anchor element is forwarded via `forwardRef` to support form libraries and programmatic focus.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-551

## Type of Change

- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

<!-- Reference Chromatic visual diffs once the CI run is complete. The StateMatrix story covers all variant × icon usage × state combinations for visual regression review. -->

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Accessibility notes

- The `<a>` element carries an implicit `role="link"` and is always accessible by keyboard.
- Disabled links retain `role="link"` and expose `aria-disabled="true"` so screen readers announce the element and its unavailable state rather than skipping it entirely.
- `tabIndex={-1}` removes disabled links from the sequential focus order while keeping them reachable programmatically.
- Icons are wrapped in `aria-hidden="true"` `<span>` containers and never carry meaningful text.
- The `label` prop is required and must be a caller-supplied translated string; raw string literals are not used inside the component.
- Focus ring uses `border-bottom` rather than `outline` per the Figma spec. This is a documented deviation from the standard MDS focus ring pattern — it applies only to the Link component and only to the `:focus-visible` pseudo-class.

## Files changed

| File | Notes |
|---|---|
| `components/link/Link.tsx` | Component implementation |
| `components/link/link.css` | Component-scoped styles using `--mds-*` tokens |
| `components/link/Link.stories.tsx` | Storybook stories: Default, Variants, WithIcons, Disabled, RightToLeft, StateMatrix |
| `components/link/Link.test.tsx` | Vitest unit tests |
| `components/link/Link.figma.tsx` | Figma Code Connect mapping (not shipped in package build) |
| `components/link/index.tsx` | Local barrel re-export |
| `components/index.tsx` | `Link` and `LinkProps` added to the public barrel |
| `components/index.css` | `@import './link/link.css'` added |

## Additional Notes

The focus ring implementation for this component deviates from the standard `outline` + `outline-offset` pattern documented in the component instructions. The Figma design specifies a bottom-only underline focus indicator (2 px `border-bottom`, 1 px gap). This is intentional and matches the visual design for links specifically, where an underline ring is semantically more appropriate than an enclosing box ring. The deviation is scoped to `Link` only and does not affect any other component.
