### PR TITLE
fix(Link): Prevent Storybook iframe navigation in play tests

### DIFF
--- a/components/link/Link.stories.tsx
+++ b/components/link/Link.stories.tsx
@@ -100,9 +100,12 @@ export const Default: Story = {
     // test runner reports a false "page closed unexpectedly" error.
     onClick: fn((e: React.MouseEvent<HTMLAnchorElement>) => e.preventDefault()),
   },
-  play: async ({ canvas, args, userEvent }) => {
+  play: async ({ canvas, args }) => {
     const link = canvas.getByRole('link', { name: args.label });
-    await userEvent.click(link);
+    // Use fireEvent instead of userEvent.click to avoid Playwright simulating a
+    // real pointer event that causes the browser to navigate before React's
+    // synthetic event (and any preventDefault) can intercept it.
+    fireEvent.click(link);
     await expect(args.onClick).toHaveBeenCalledTimes(1);
   },
 };


### PR DESCRIPTION
## Description

There was a problem in ZH page for the Link component where the Storybook page always having the link itself being triggered.

This PR is to fix that, enabling the ZH page to display the link component appropriately with the controls displayed

## Related Jira or GitHub Issue

N/A

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews
<img width="1223" height="913" alt="Screenshot 2026-06-26 at 4 41 01 pm" src="https://github.com/user-attachments/assets/3c119152-ed58-45a6-9e77-f4ff17725896" />

## Checklist

- [ ] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [ ] I have considered accessibility and described any improvements or issues
- [ ] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

N/A