### PR TITLE
fix(FavouriteButton): Adjust the color from text-default to text-subtle

### DIFF
--- a/components/favourite-button/favourite-button.css
+++ b/components/favourite-button/favourite-button.css
@@ -8,7 +8,7 @@
   border: none;
   border-radius: var(--mds-border-radius-pill);
   background-color: var(--mds-bg-surface-default);
-  color: var(--mds-text-default);
+  color: var(--mds-text-subtle);
   cursor: pointer;
   transition:
     background-color 0.15s ease-in-out,
@@ -43,7 +43,7 @@
 
 .mds-favourite-button:active:not(:disabled) {
   background-color: var(--mds-bg-surface-strong);
-  color: var(--mds-text-default);
+  color: var(--mds-text-subtle);
 }
 
 /* Selected states */


### PR DESCRIPTION
## Description

This change updates FavouriteButton text color tokens from text-default to text-subtle in the unselected interaction states to better match the intended visual hierarchy.

**What changed:**

- Updated the base state color to use `--mds-text-subtle`.
- Updated the active (not disabled) state color to use `--mds-text-subtle`.

No structural, behavioral, or API changes were made.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-608

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

Before:
<img width="89" height="87" alt="Screenshot 2026-07-03 at 1 54 58 pm" src="https://github.com/user-attachments/assets/9987d00d-072e-474f-b7fd-20cfda27cbc8" />
After: 
<img width="54" height="85" alt="Screenshot 2026-07-03 at 1 54 43 pm" src="https://github.com/user-attachments/assets/f83649c4-5292-41b1-a9a3-e713dd529fe1" />

## Checklist

- [ ] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [ ] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

N/A