### PR TITLE
feat(Tooltip): Add new Tooltip component

### DIFF
--- a/.github/instructions/component-index.instructions.md
+++ b/.github/instructions/component-index.instructions.md
@@ -23,6 +23,7 @@ Quick reference for AI agents and developers.
 | Pagination      | Page navigation control                                    | totalPages, currentPage, onPageChange, ariaLabel |
 | ProgressBar     | Visual progress indicator with status and label variants   | value, min, max, status, labelVariant, title     |
 | Radio           | Single-select options in a group                           | checked, label, disabled, invalid                |
+| Tooltip         | Contextual label anchored to a trigger element             | label, placement, variant, children              |
 
 ## Component Links
 
@@ -52,6 +53,8 @@ Quick reference for AI agents and developers.
 - [ProgressBar stories](../../components/progress-bar/ProgressBar.stories.tsx)
 - [Radio implementation](../../components/radio/Radio.tsx)
 - [Radio stories](../../components/radio/Radio.stories.tsx)
+- [Tooltip implementation](../../components/tooltip/Tooltip.tsx)
+- [Tooltip stories](../../components/tooltip/Tooltip.stories.tsx)
 
 ## Working Rules
 

--- a/components/index.css
+++ b/components/index.css
@@ -11,3 +11,4 @@
 @import './pagination/pagination.css';
 @import './progress-bar/progress-bar.css';
 @import './radio/radio.css';
+@import './tooltip/tooltip.css';

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -36,3 +36,6 @@ export type { ProgressBarProps } from './progress-bar';
 
 export { Radio } from './radio';
 export type { RadioProps } from './radio';
+
+export { Tooltip } from './tooltip';
+export type { TooltipProps } from './tooltip';

--- a/components/tooltip/Tooltip.figma.tsx
+++ b/components/tooltip/Tooltip.figma.tsx
@@ -1,0 +1,28 @@
+import figma from '@figma/code-connect';
+import { Button } from '../button';
+import { Tooltip } from './Tooltip';
+
+figma.connect(
+  Tooltip,
+  'https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=11558-438',
+  {
+    props: {
+      label: figma.string('Text'),
+      placement: figma.enum('Placement', {
+        Top: 'top',
+        Bottom: 'bottom',
+        Left: 'left',
+        Right: 'right',
+      }),
+      variant: figma.enum('Variant', {
+        Dark: 'dark',
+        Light: 'light',
+      }),
+    },
+    example: ({ label, placement, variant }) => (
+      <Tooltip label={label} placement={placement} variant={variant}>
+        <Button label="Hover me" variant="secondary" />
+      </Tooltip>
+    ),
+  },
+);

--- a/components/tooltip/Tooltip.stories.tsx
+++ b/components/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,274 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type React from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Button } from '../button';
+import { Tooltip } from './Tooltip';
+
+const placements = ['left', 'top', 'bottom', 'right'] as const;
+const variants = ['dark', 'light'] as const;
+
+const showcaseRowCompactStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '24px',
+  flexWrap: 'wrap',
+};
+
+const showcaseRowStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '144px',
+  flexWrap: 'wrap',
+};
+
+const showcaseCellStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+const showcaseParameters = {
+  controls: { disable: true },
+  docs: {
+    canvas: { sourceState: 'none' as const },
+  },
+};
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs', 'test', 'stable'],
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'Tooltip text. Must be a caller-supplied translated string.',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    placement: {
+      control: { type: 'select' },
+      options: ['top', 'bottom', 'left', 'right'],
+      description:
+        'Preferred physical side of the trigger. Auto-flips to avoid viewport edges. In RTL, left and right still mean viewport-left and viewport-right.',
+      table: {
+        type: { summary: 'top | bottom | left | right' },
+        defaultValue: { summary: 'top' },
+      },
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['dark', 'light'],
+      description: 'Colour mode.',
+      table: {
+        type: { summary: 'dark | light' },
+        defaultValue: { summary: 'dark' },
+      },
+    },
+  },
+  args: {
+    label: 'This is a tooltip',
+    placement: undefined,
+    variant: undefined,
+    children: <Button label="Hover me" variant="secondary" />,
+  },
+  decorators: [
+    (Story) => (
+      // Extra padding ensures the tooltip bubble is fully visible in the story canvas.
+      <div style={{ padding: '64px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
+    const trigger = canvas.getByRole('button', { name: 'Hover me' });
+    expect(trigger).toBeInTheDocument();
+
+    await userEvent.hover(trigger);
+
+    const tooltip = page.getByRole('tooltip', { hidden: true });
+    await waitFor(() => expect(tooltip).toHaveAttribute('data-open'));
+    expect(tooltip).toHaveTextContent('This is a tooltip');
+  },
+};
+
+/**
+ * Icon-only controls are a common tooltip trigger. Keep the trigger's
+ * accessible name and expose the tooltip as additional description.
+ */
+export const IconOnlyTrigger: Story = {
+  args: {
+    label: 'More actions for this item',
+  },
+  render: (args) => (
+    <Tooltip label={args.label}>
+      <Button
+        label=""
+        aria-label="More options"
+        variant="secondary"
+        startIcon={<i className="fa-solid fa-ellipsis" aria-hidden="true" />}
+      />
+    </Tooltip>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
+    const trigger = canvas.getByRole('button', { name: 'More options' });
+
+    await userEvent.hover(trigger);
+
+    const tooltip = page.getByRole('tooltip', { hidden: true });
+    await waitFor(() => expect(tooltip).toHaveAttribute('data-open'));
+    expect(tooltip).toHaveTextContent(args.label as string);
+
+    const describedBy = trigger.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(describedBy?.split(/\s+/).filter(Boolean)).toContain(tooltip.id);
+    expect(trigger).toHaveAccessibleName('More options');
+  },
+};
+
+/**
+ * Shows all supported visual variants with a fixed placement.
+ */
+export const Variants: Story = {
+  parameters: showcaseParameters,
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    await waitFor(() =>
+      expect(page.getAllByRole('tooltip', { hidden: true })).toHaveLength(
+        variants.length,
+      ),
+    );
+
+    const tooltips = page.getAllByRole('tooltip', { hidden: true });
+    const openTooltips = tooltips.filter((tooltip) =>
+      tooltip.hasAttribute('data-open'),
+    );
+
+    expect(tooltips).toHaveLength(variants.length);
+    expect(openTooltips).toHaveLength(variants.length);
+
+    for (const [index, variant] of variants.entries()) {
+      expect(tooltips[index]).toHaveTextContent(
+        `Tooltip with ${variant} variant`,
+      );
+    }
+  },
+  render: () => (
+    <div style={showcaseRowStyle}>
+      {variants.map((variant) => (
+        <div key={variant} style={showcaseCellStyle}>
+          <Tooltip
+            label={`Tooltip with ${variant} variant`}
+            variant={variant}
+            data-forced-open=""
+          >
+            <Button
+              label={`${variant[0].toUpperCase()}${variant.slice(1)}`}
+              variant="secondary"
+            />
+          </Tooltip>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * Shows all supported placements with a fixed visual variant.
+ */
+export const Placements: Story = {
+  parameters: showcaseParameters,
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    await waitFor(() =>
+      expect(page.getAllByRole('tooltip', { hidden: true })).toHaveLength(
+        placements.length,
+      ),
+    );
+
+    const tooltips = page.getAllByRole('tooltip', { hidden: true });
+    const openTooltips = tooltips.filter((tooltip) =>
+      tooltip.hasAttribute('data-open'),
+    );
+
+    expect(tooltips).toHaveLength(placements.length);
+    expect(openTooltips).toHaveLength(placements.length);
+
+    for (const [index, placement] of placements.entries()) {
+      expect(tooltips[index]).toHaveTextContent(`Tooltip on the ${placement}`);
+    }
+  },
+  render: () => (
+    <div style={showcaseRowCompactStyle}>
+      {placements.map((placement) => (
+        <div key={placement} style={showcaseCellStyle}>
+          <Tooltip
+            label={`Tooltip on the ${placement}`}
+            placement={placement}
+            data-forced-open=""
+          >
+            <Button
+              label={`${placement[0].toUpperCase()}${placement.slice(1)}`}
+              variant="secondary"
+            />
+          </Tooltip>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** Pressing Escape while open should dismiss the tooltip (WCAG 2.1 SC 1.4.13). */
+export const EscapeDismiss: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
+    const trigger = canvas.getByRole('button', { name: 'Hover me' });
+    const tooltip = page.getByRole('tooltip', { hidden: true });
+
+    await userEvent.hover(trigger);
+    await waitFor(() => expect(tooltip).toHaveAttribute('data-open'));
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(tooltip).not.toHaveAttribute('data-open'));
+  },
+};
+
+/**
+ * Floating UI placement values are physical, not logical. In RTL, `left` still
+ * means viewport-left, so `right` is used to place on inline-start.
+ */
+export const RightToLeft: Story = {
+  tags: ['test', 'stable'],
+  decorators: [
+    (Story) => (
+      <div dir="rtl" lang="ar" style={{ padding: '64px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    label: 'هذه تلميحة',
+    placement: 'right',
+    children: <Button label="مرر هنا" variant="secondary" />,
+  },
+};

--- a/components/tooltip/Tooltip.test.tsx
+++ b/components/tooltip/Tooltip.test.tsx
@@ -1,0 +1,329 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { Button } from '../button';
+import { Tooltip } from './Tooltip';
+
+describe('Tooltip: Unit Test', () => {
+  describe('rendering', () => {
+    it('applies default host class, forwards props, and merges className', () => {
+      const { container } = render(
+        <Tooltip label="Info" data-testid="my-tooltip" className="custom-class">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+
+      expect(container.firstChild).toHaveAttribute('data-testid', 'my-tooltip');
+      expect(container.firstChild).toHaveClass('mds-tooltip', 'custom-class');
+    });
+
+    it('keeps data-forced-open on the bubble, not on the wrapper', () => {
+      const { container } = render(
+        <Tooltip label="Info" data-forced-open="">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+
+      const wrapper = container.firstChild as HTMLDivElement;
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+      expect(wrapper).not.toHaveAttribute('data-forced-open');
+      expect(tooltip).toHaveAttribute('data-forced-open', '');
+    });
+
+    it('renders the tooltip label text in the bubble', () => {
+      render(
+        <Tooltip label="Helper text">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent(
+        'Helper text',
+      );
+    });
+
+    it('renders the trigger children', () => {
+      render(
+        <Tooltip label="Info">
+          <Button label="Click me" />
+        </Tooltip>,
+      );
+      expect(
+        screen.getByRole('button', { name: 'Click me' }),
+      ).toBeInTheDocument();
+    });
+
+    it('sets role="tooltip" on the bubble element', () => {
+      render(
+        <Tooltip label="Info">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+      expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument();
+    });
+
+    it('links the trigger to the tooltip with aria-describedby', () => {
+      render(
+        <Tooltip label="Info">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+    });
+
+    it('uses aria-label in auto mode when the trigger has no likely accessible name', () => {
+      render(
+        <Tooltip label="Icon action">
+          <button type="button" aria-hidden="false">
+            <span aria-hidden="true">*</span>
+          </button>
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Icon action' });
+      expect(trigger).toHaveAttribute('aria-label', 'Icon action');
+      expect(trigger).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('preserves an existing aria-describedby value on the trigger', () => {
+      render(
+        <Tooltip label="Info">
+          <Button label="Trigger" aria-describedby="existing-description" />
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      const describedBy = trigger.getAttribute('aria-describedby') ?? '';
+      expect(describedBy).toContain('existing-description');
+      expect(describedBy).toContain(tooltip.id);
+    });
+
+    it('deduplicates repeated aria-describedby ids', () => {
+      render(
+        <Tooltip label="Info">
+          <Button
+            label="Trigger"
+            aria-describedby="existing-description existing-description"
+          />
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const describedBy = trigger.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+
+      const describedByIds = (describedBy ?? '').split(/\s+/).filter(Boolean);
+      expect(describedByIds).toContain('existing-description');
+      expect(new Set(describedByIds).size).toBe(describedByIds.length);
+
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      expect(describedByIds).toContain(tooltip.id);
+    });
+
+    it('preserves an existing aria-label value in auto mode', () => {
+      render(
+        <Tooltip label="Icon action">
+          <button type="button" aria-label="Custom action" />
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Custom action' });
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      expect(trigger).toHaveAttribute('aria-label', 'Custom action');
+      expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+    });
+
+    it('bubble is hidden by default (no data-open attribute)', () => {
+      render(
+        <Tooltip label="Info">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      expect(tooltip).not.toHaveAttribute('data-open');
+    });
+
+    it('opens on hover, gets positioned, and closes on mouse leave', async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip label="Info">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+      await user.hover(trigger);
+      await waitFor(() => expect(tooltip).toHaveAttribute('data-open'));
+      await waitFor(() => expect(tooltip).toHaveAttribute('data-positioned'));
+
+      await user.unhover(trigger);
+      await waitFor(() => expect(tooltip).not.toHaveAttribute('data-open'));
+    });
+
+    it('opens on focus and closes when focus leaves the trigger', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <Tooltip label="Info">
+            <Button label="Trigger" />
+          </Tooltip>
+          <Button label="Next" />
+        </>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const next = screen.getByRole('button', { name: 'Next' });
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+      await user.tab();
+      expect(trigger).toHaveFocus();
+      await waitFor(() => expect(tooltip).toHaveAttribute('data-open'));
+
+      await user.tab();
+      expect(next).toHaveFocus();
+      await waitFor(() => expect(tooltip).not.toHaveAttribute('data-open'));
+    });
+
+    it('dismisses on Escape key after opening (WCAG 2.1 SC 1.4.13)', async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip label="Info">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+      await user.hover(trigger);
+      await waitFor(() => expect(tooltip).toHaveAttribute('data-open'));
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(tooltip).not.toHaveAttribute('data-open'));
+    });
+
+    it('supports touch tap toggle and outside-click dismissal', async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip label="Info">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+      // Simulate a touch tap (pointerType: 'touch') — mouse hover never fires on touch devices.
+      await user.pointer({ keys: '[TouchA]', target: trigger });
+      await waitFor(() => expect(tooltip).toHaveAttribute('data-open'));
+
+      // Second touch tap should close.
+      await user.pointer({ keys: '[TouchA]', target: trigger });
+      await waitFor(() => expect(tooltip).not.toHaveAttribute('data-open'));
+
+      // Re-open via touch and assert outside click dismissal.
+      await user.pointer({ keys: '[TouchA]', target: trigger });
+      await waitFor(() => expect(tooltip).toHaveAttribute('data-open'));
+
+      await user.click(document.body);
+      await waitFor(() => expect(tooltip).not.toHaveAttribute('data-open'));
+    });
+
+    it('fails gracefully when children is not a valid React element', () => {
+      expect(() =>
+        render(
+          <Tooltip label="Info">
+            {
+              // @ts-expect-error deliberately invalid runtime value
+              'Trigger text'
+            }
+          </Tooltip>,
+        ),
+      ).not.toThrow();
+
+      expect(
+        screen.queryByRole('tooltip', { hidden: true }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('placement fallback', () => {
+    it('accepts all valid placement values without warnings', () => {
+      (['top', 'bottom', 'left', 'right'] as const).forEach((placement) => {
+        const { unmount } = render(
+          <Tooltip label="Info" placement={placement}>
+            <Button label="Trigger" />
+          </Tooltip>,
+        );
+        expect(
+          screen.getByRole('tooltip', { hidden: true }),
+        ).toBeInTheDocument();
+        unmount();
+      });
+    });
+
+    it('falls back gracefully for an invalid placement value', () => {
+      expect(() =>
+        render(
+          // @ts-expect-error deliberately invalid value
+          <Tooltip label="Info" placement="diagonal">
+            <Button label="Trigger" />
+          </Tooltip>,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe('variant', () => {
+    it('applies the expected bubble class for valid and invalid variants', () => {
+      const cases: Array<{
+        name: string;
+        variant?: 'light';
+        expectedClass:
+          'mds-tooltip__bubble--dark' | 'mds-tooltip__bubble--light';
+        unexpectedClass?: 'mds-tooltip__bubble--neon';
+      }> = [
+        {
+          name: 'default variant',
+          expectedClass: 'mds-tooltip__bubble--dark',
+        },
+        {
+          name: 'light variant',
+          variant: 'light',
+          expectedClass: 'mds-tooltip__bubble--light',
+        },
+      ];
+
+      cases.forEach(({ name, variant, expectedClass, unexpectedClass }) => {
+        const { unmount } = render(
+          <Tooltip label="Info" variant={variant}>
+            <Button label="Trigger" />
+          </Tooltip>,
+        );
+
+        const tooltip = screen.getByRole('tooltip', { hidden: true });
+        expect(tooltip, name).toHaveClass(expectedClass);
+        if (unexpectedClass) {
+          expect(tooltip, name).not.toHaveClass(unexpectedClass);
+        }
+        unmount();
+      });
+
+      render(
+        // @ts-expect-error deliberately invalid value
+        <Tooltip label="Info" variant="neon">
+          <Button label="Trigger" />
+        </Tooltip>,
+      );
+      const invalidTooltip = screen.getByRole('tooltip', { hidden: true });
+      expect(invalidTooltip).toHaveClass('mds-tooltip__bubble--dark');
+      expect(invalidTooltip).not.toHaveClass('mds-tooltip__bubble--neon');
+    });
+  });
+});

--- a/components/tooltip/Tooltip.tsx
+++ b/components/tooltip/Tooltip.tsx
@@ -1,0 +1,261 @@
+import {
+  FloatingArrow,
+  FloatingPortal,
+  arrow,
+  autoUpdate,
+  flip,
+  limitShift,
+  offset,
+  shift,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useMergeRefs,
+  useRole,
+} from '@floating-ui/react';
+import type { HTMLAttributes, ReactElement, Ref } from 'react';
+import { cloneElement, isValidElement, useEffect, useState } from 'react';
+
+type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+type TooltipVariant = 'dark' | 'light';
+
+export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
+  /** Tooltip text displayed in the popup. Must be a caller-supplied translated string. */
+  label: string;
+  /** Preferred physical side of the trigger the tooltip appears on. Defaults to `top`. Auto-flips to avoid viewport edges. In RTL, `left` and `right` still mean viewport-left and viewport-right. */
+  placement?: TooltipPlacement;
+  /** Colour mode. `dark` uses a dark background with light text; `light` uses a light background with dark text. Defaults to `dark`. */
+  variant?: TooltipVariant;
+  /** The trigger element. Must be a single React element that forwards refs. */
+  children: ReactElement;
+}
+
+const allowedPlacements: TooltipPlacement[] = [
+  'top',
+  'bottom',
+  'left',
+  'right',
+];
+const allowedVariants: TooltipVariant[] = ['dark', 'light'];
+
+const hasTextChildren = (value: unknown): boolean => {
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  if (typeof value === 'number') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(hasTextChildren);
+  }
+
+  return false;
+};
+
+const ARROW_HEIGHT = 6;
+const ARROW_WIDTH = 12;
+const ARROW_GAP = 8;
+
+export const Tooltip = ({
+  label,
+  placement = 'top',
+  variant = 'dark',
+  children,
+  className,
+  ...props
+}: TooltipProps) => {
+  // Internal story/test hook: extract from rest props so it is not forwarded to the wrapper.
+  const { 'data-forced-open': dataForcedOpen, ...wrapperProps } =
+    props as TooltipProps & { 'data-forced-open'?: string };
+  const [isOpen, setIsOpen] = useState(false);
+  const isForcedOpen = dataForcedOpen !== undefined;
+  const isTooltipOpen = isForcedOpen || isOpen;
+  // useState (not useRef) is intentional: updating the state triggers a re-render
+  // so Floating UI re-measures the arrow element after it mounts.
+  const [arrowEl, setArrowEl] = useState<SVGSVGElement | null>(null);
+
+  // Runtime fallback — warn in dev and use defaults for invalid values.
+  // useEffect keeps warnings from repeating on internal open/close state renders.
+  useEffect(() => {
+    if (
+      import.meta.env.DEV &&
+      !allowedPlacements.includes(placement as TooltipPlacement)
+    ) {
+      console.warn(
+        `[MDS Tooltip] Invalid placement "${placement}". Falling back to "top". Allowed: ${allowedPlacements.join(', ')}`,
+      );
+    }
+
+    if (
+      import.meta.env.DEV &&
+      !allowedVariants.includes(variant as TooltipVariant)
+    ) {
+      console.warn(
+        `[MDS Tooltip] Invalid variant "${variant}". Falling back to "dark". Allowed: ${allowedVariants.join(', ')}`,
+      );
+    }
+  }, [placement, variant]);
+
+  const resolvedPlacement = allowedPlacements.includes(
+    placement as TooltipPlacement,
+  )
+    ? placement
+    : 'top';
+  const resolvedVariant = allowedVariants.includes(variant as TooltipVariant)
+    ? variant
+    : 'dark';
+
+  const { refs, floatingStyles, context, isPositioned, update } = useFloating({
+    open: isTooltipOpen,
+    onOpenChange: (nextOpen) => {
+      if (!isForcedOpen) {
+        setIsOpen(nextOpen);
+      }
+    },
+    placement: resolvedPlacement,
+    middleware: [
+      offset(ARROW_HEIGHT + ARROW_GAP),
+      flip(),
+      shift({ padding: 8, limiter: limitShift() }),
+      arrow({ element: arrowEl, padding: 4 }),
+    ],
+    // The isTooltipOpen guard ensures autoUpdate does not unnecessarily attach scroll and
+    // resize listeners to every tooltip on the page — even closed ones. FloatingPortal
+    // keeps the bubble in the DOM at all times, so both elements are always mounted.
+    whileElementsMounted: isTooltipOpen ? autoUpdate : undefined,
+  });
+
+  const { setReference, setFloating } = refs;
+
+  // Force an immediate position recalculation when the tooltip opens.
+  // autoUpdate handles continuous updates while mounted, but does not
+  // guarantee a fresh measurement on the exact frame the tooltip becomes visible.
+  useEffect(() => {
+    if (isTooltipOpen) {
+      update();
+    }
+  }, [isTooltipOpen, update]);
+
+  const hover = useHover(context, {
+    move: false,
+    delay: { open: 200, close: 0 },
+  });
+  const focus = useFocus(context);
+  // useClick enables tap-to-toggle on touch devices where hover never fires.
+  // ignoreMouse prevents double-firing on pointer devices that also emit click.
+  const click = useClick(context, { ignoreMouse: true });
+  const dismiss = useDismiss(context, { outsidePress: true });
+  const role = useRole(context, { role: 'tooltip' });
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    hover,
+    focus,
+    click,
+    dismiss,
+    role,
+  ]);
+
+  const wrapperClassName = [
+    'mds-tooltip',
+    `mds-tooltip--${resolvedVariant}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const triggerElement = isValidElement(children)
+    ? (children as ReactElement<{
+        'aria-describedby'?: string;
+        'aria-label'?: string;
+        'aria-labelledby'?: string;
+        label?: string;
+        ref?: Ref<HTMLElement>;
+        [key: string]: unknown;
+      }>)
+    : null;
+  const childRef = triggerElement?.props.ref;
+  const mergedTriggerRef = useMergeRefs([setReference, childRef]);
+
+  if (!triggerElement) {
+    if (import.meta.env.DEV) {
+      console.error(
+        '[MDS Tooltip] children must be a single React element that forwards refs.',
+      );
+    }
+
+    return <div className={wrapperClassName} {...props} />;
+  }
+
+  const existingDescribedBy = triggerElement.props['aria-describedby'] ?? '';
+  const describedByIds = new Set([
+    ...existingDescribedBy.split(/\s+/).filter(Boolean),
+    context.floatingId,
+  ]);
+  const existingAriaLabel = triggerElement.props['aria-label'];
+  const hasLikelyAccessibleName =
+    Boolean(existingAriaLabel) ||
+    Boolean(triggerElement.props['aria-labelledby']) ||
+    Boolean(triggerElement.props.label?.trim()) ||
+    hasTextChildren(triggerElement.props.children);
+  const resolvedAriaStrategy = hasLikelyAccessibleName
+    ? 'description'
+    : 'label';
+
+  const trigger = cloneElement(triggerElement, {
+    ...getReferenceProps(triggerElement.props),
+    ...(resolvedAriaStrategy === 'description'
+      ? {
+          'aria-describedby': Array.from(describedByIds).join(' '),
+        }
+      : {
+          // In label mode, the tooltip text becomes the trigger's accessible name.
+          // Preserve a caller-supplied aria-label when present.
+          'aria-label': existingAriaLabel ?? label,
+        }),
+    ref: mergedTriggerRef,
+  });
+
+  return (
+    <div
+      // mds-tooltip--{variant} on the wrapper is intentionally kept for
+      // consumer-side targeting (e.g. styling the trigger area per variant).
+      // Variant-specific bubble styles live on mds-tooltip__bubble--{variant}.
+      className={wrapperClassName}
+      {...wrapperProps}
+    >
+      {trigger}
+      <FloatingPortal>
+        <div
+          ref={setFloating}
+          style={floatingStyles}
+          className={[
+            'mds-tooltip__bubble',
+            `mds-tooltip__bubble--${resolvedVariant}`,
+          ].join(' ')}
+          id={context.floatingId}
+          // data-open has no CSS effect — it is used only in tests to assert open state.
+          data-open={isTooltipOpen ? '' : undefined}
+          data-positioned={isTooltipOpen && isPositioned ? '' : undefined}
+          data-forced-open={dataForcedOpen}
+          {...getFloatingProps()}
+        >
+          <div className="mds-tooltip__content">
+            <span className="mds-tooltip__text">{label}</span>
+          </div>
+          <FloatingArrow
+            ref={setArrowEl}
+            context={context}
+            width={ARROW_WIDTH}
+            height={ARROW_HEIGHT}
+            className="mds-tooltip__arrow"
+          />
+        </div>
+      </FloatingPortal>
+    </div>
+  );
+};

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -1,0 +1,1 @@
+export * from './Tooltip';

--- a/components/tooltip/tooltip.css
+++ b/components/tooltip/tooltip.css
@@ -1,0 +1,102 @@
+/* ─── Host wrapper ─────────────────────────────────────────────────────────── */
+
+.mds-tooltip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ─── Bubble ───────────────────────────────────────────────────────────────── */
+
+/*
+ * The bubble is rendered with FloatingPortal into document.body. This avoids
+ * clipping from overflow/transform ancestors while Floating UI controls
+ * placement via inline top/left styles.
+ */
+.mds-tooltip__bubble {
+  z-index: 1080;
+
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.1s ease,
+    visibility 0.1s ease;
+
+  white-space: normal;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mds-tooltip__bubble {
+    transition: none;
+  }
+}
+
+/*
+ * data-positioned appears once Floating UI computes a final position, preventing
+ * a top-left flash before the first measurement pass completes.
+ *
+ * data-forced-open is an internal story/test hook that bypasses interaction timing.
+ */
+.mds-tooltip__bubble[data-positioned],
+.mds-tooltip__bubble[data-forced-open] {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ─── Content box ───────────────────────────────────────────────────────────── */
+
+.mds-tooltip__content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: max-content;
+  max-width: 200px;
+  min-inline-size: 0;
+  padding: var(--mds-spacing-xxs) var(--mds-spacing-xs);
+  border-radius: var(--mds-border-radius-sm);
+  background-color: var(--mds-bg-feedback-secondary-dark);
+}
+
+.mds-tooltip__bubble--light .mds-tooltip__content {
+  background-color: var(--mds-bg-feedback-secondary-default);
+}
+
+/* ─── Text ──────────────────────────────────────────────────────────────────── */
+
+.mds-tooltip__text {
+  display: block;
+  max-inline-size: 100%;
+  min-inline-size: 0;
+  font-family: var(--mds-font-family-base);
+  font-weight: var(--mds-font-weight-regular);
+  font-size: var(--mds-font-size-paragraph-small);
+  line-height: var(--mds-line-height-paragraph-small);
+  letter-spacing: var(--mds-letter-spacing-default);
+  /*
+   * Keep natural word boundaries for readable text, but still force wrapping
+   * for long unbroken tokens (for example URLs) so the bubble never overflows.
+   */
+  word-break: normal;
+  overflow-wrap: anywhere;
+
+  color: var(--mds-text-inverse);
+  text-align: center;
+}
+
+.mds-tooltip__bubble--light .mds-tooltip__text {
+  color: var(--mds-text-default);
+}
+
+/* ─── Arrow ─────────────────────────────────────────────────────────────────── */
+
+/* FloatingArrow writes an SVG path; fill must target the path nodes directly. */
+.mds-tooltip__arrow path {
+  fill: var(--mds-bg-feedback-secondary-dark);
+}
+
+.mds-tooltip__bubble--light .mds-tooltip__arrow path {
+  fill: var(--mds-bg-feedback-secondary-default);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@moodlehq/design-system",
       "version": "5.2.0",
       "license": "GPL-3.0-only",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.19"
+      },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.0.0",
         "@commitlint/cli": "^21.0.1",
@@ -2012,6 +2015,59 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "7.3.1",
@@ -13155,6 +13211,12 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "sideEffects": [
     "**/*.css"
   ],
+  "dependencies": {
+    "@floating-ui/react": "^0.27.19"
+  },
   "peerDependencies": {
     "bootstrap": "^5.3.0",
     "react": "^19.2.4",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -227,7 +227,15 @@ export default defineConfig({
     },
     cssCodeSplit: false, // Bundle all CSS into a single inlined dist/index.css for full-build direct URL loading.
     rollupOptions: {
-      external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime'],
+      external: (id) =>
+        [
+          'react',
+          'react-dom',
+          'react-dom/client',
+          'react/jsx-runtime',
+        ].includes(id) ||
+        id.startsWith('@floating-ui/') ||
+        id === 'tabbable',
       output: {
         assetFileNames: 'index.css', // Name the full-build inlined CSS bundle.
         // Transpile every source file into its own output file with a stable, predictable


### PR DESCRIPTION
## Description

This PR introduces a new Tooltip component designed for accessible, token-driven, RTL-safe usage across Moodle UI.
Key implementation details:

- Added a new Tooltip component with configurable placement (top, bottom, left, right) and variant (dark, light).
- Implemented runtime validation for placement and variant values with graceful fallback to documented defaults:
  - Invalid placement falls back to top.
  - Invalid variant falls back to dark.
- Added accessible trigger-to-tooltip linking:
  - Tooltip bubble id comes from Floating UI context id.
  - If the child is a valid React element, Tooltip clones the trigger and applies accessibility attributes.
  - Existing `aria-describedby` values are preserved and deduplicated when description mode is used.
  - If the trigger does not appear to have an accessible name, Tooltip falls back to aria-label mode.
  - Tooltip bubble renders with `role="tooltip"`.
- Added robust trigger handling:
  - Invalid child usage fails gracefully without throwing.
  - Development logs are emitted for invalid usage patterns.
- Implemented token-based styling and RTL-safe logical sizing:
  - Uses design tokens for color, typography, spacing, and radius.
  - Uses logical inline sizing properties for RTL/LTR compatibility.
  - Includes reduced-motion handling for tooltip transitions.
- Implemented arrow rendering with Floating UI FloatingArrow (SVG path-based), with variant-aware token coloring.
- Implemented always-visible behavior for showcase stories by using Storybook pseudo states (pseudo.hover targeting `.mds-tooltip`) in shared showcaseParameters, so tooltip bubbles render visible for visual review without adding a force-visible CSS modifier or changing runtime Tooltip behavior.
- Uses the dark feedback background token for the default dark tooltip appearance

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-499

## Screenshots/Previews

<img width="1052" height="735" alt="Screenshot 2026-07-08 at 10 16 16 am" src="https://github.com/user-attachments/assets/d11b0009-dda3-4f19-9ce3-1e3cd7dd1505" />

## Author checklist

### File structure and exports

- [x] All 5 required files present: `ComponentName.tsx`, `component-name.css`, `ComponentName.test.tsx`, `ComponentName.stories.tsx`, `index.tsx`
- [x] `ComponentName.figma.tsx` Code Connect file created and published
- [x] Named and type exports added to `components/index.tsx`
- [x] Component stylesheet imported in `components/index.css`

### TypeScript and props

- [x] Props interface extends the correct React HTML element interface (e.g. `ButtonHTMLAttributes<HTMLButtonElement>`)
- [x] JSDoc comment on each prop
- [x] Constrained props use `allowedValues` runtime validation with a graceful fallback to a documented default
- [x] `...props` spread last on the host element

### Internationalisation

- [x] All user-facing strings accepted as props — no hardcoded text in JSX
- [x] CSS uses logical properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`) for any directional layout
- [x] RTL story added if the component has directional layout

### CSS and tokens

- [x] All CSS values use `var(--mds-*)` tokens — no hardcoded colours, spacing, or typography
- [x] Where a matching token exists, `var(--mds-*)` is used without fallback literals (for example, `var(--mds-spacing-xs)`, not `var(--mds-spacing-xs, 0.5rem)`)

### Tests and stories

- [x] Unit tests cover: `mds-*` class on root, correct classes per variant/size, invalid prop fallback, prop forwarding, disabled state, and label rendering
- [x] Storybook stories cover all documented variants, sizes, and states
- [x] Accessibility tested — Axe WCAG AA scan runs automatically via CI on all stories tagged `test`

### Breaking changes

- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump

### AI context

- [x] Instruction files updated if this component introduces new patterns or anti-patterns

## Cross-system parity

- [x] Component name, prop names, and variant names are consistent across code, Storybook, Figma, and Zeroheight

## Additional Notes

N/A