### PR TITLE
ci: Update Node version in GHA

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.22.1
+          node-version: 22.22.2
 
       - name: Install commitlint
         run: npm install -D @commitlint/cli @commitlint/config-conventional

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.22.1
+          node-version: 22.22.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/sync-zeroheight-docs.yml
+++ b/.github/workflows/sync-zeroheight-docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.22.1
+          node-version: 22.22.2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  NODE_VERSION: 22.22.1
+  NODE_VERSION: 22.22.2
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Bumps the pinned Node.js version from `22.22.1` to `22.22.2` across all GitHub Actions workflows.

`npm@latest` (12.0.0) raised its engine requirement to `^22.22.2 || ^24.15.0 || >=26.0.0`. The `publish-package` workflow runs `npm install -g npm@latest` before `npm ci`, so it was failing with `EBADENGINE` because the runner was on Node `22.22.1`, which falls just short of the minimum.

All four workflow files that pin a Node version have been updated for consistency.

## Related Jira or GitHub Issue

<!-- No ticket — reactive fix to a broken publish workflow -->

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [x] Other (please describe)

CI maintenance: Node version bump to satisfy updated `npm@latest` engine requirement.

## Screenshots/Previews

N/A — workflow-only change, no UI impact.

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

Changed files:
- `.github/workflows/publish-package.yml` — direct cause of the failure
- `.github/workflows/testing.yml` — uses a shared `NODE_VERSION` env var
- `.github/workflows/commitlint.yml` — inline pin updated
- `.github/workflows/sync-zeroheight-docs.yml` — inline pin updated
