### PR TITLE
fix(Typescript): Add optional TypeScript peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This repository follows these standards:
 ### Prerequisites
 
 - Node.js v22.22.1 or higher
+- TypeScript 5.0 or higher is required for consumers that type-check this package.
 - npm
 - Git
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,13 @@
   "peerDependencies": {
     "bootstrap": "^5.3.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.0",


### PR DESCRIPTION
## Description

Adds `typescript: ">=5.0.0"` as an optional peer dependency in `package.json` and documents the TypeScript 5+ requirement in the README prerequisites section.

This change surfaces the minimum supported TypeScript version earlier for consumers. The package publishes `.d.ts` files that use TypeScript 5.x features, so consumers on TypeScript 4.x can otherwise hit confusing type errors with no clear guidance.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-611

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

N/A. This change only updates package metadata and documentation.

## Checklist

- [ ] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

No code changes were made.

Tests were not run because this is a metadata and documentation-only change.

`typescript` is intentionally marked as an optional peer dependency so the minimum supported version is visible in npm/tooling without forcing installation for consumers that do not type-check against the package.