### PR TITLE
chore(Bootstrap): Move Bootstrap to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ import '@moodlehq/design-system/css';
 import { Button } from '@moodlehq/design-system/components/button';
 ```
 
+### Bootstrap Compatibility
+
+MDS couples to Bootstrap **CSS class names** in component JSX and styles.
+This package does **not** import or depend on Bootstrap JavaScript at runtime.
+
+Install a Bootstrap version compatible with your MDS release line:
+
+| MDS release line | Supported Bootstrap version |
+| ---------------- | --------------------------- |
+| 5.x              | 5.3.x                       |
+
+Bootstrap major upgrades that rename or remove CSS classes (for example, `5.x` to `6.x`) require a corresponding MDS major version bump.
+
 ### Fonts
 
 The recommended typeface for Moodle Design System is **[Noto Sans](https://fonts.google.com/specimen/Noto+Sans)**. The package does not bundle font files. Provide Noto Sans in your application:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@moodlehq/design-system",
       "version": "5.1.2",
       "license": "GPL-3.0-only",
-      "dependencies": {
-        "bootstrap": "^5.3.8"
-      },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.0.0",
         "@commitlint/cli": "^21.0.1",
@@ -73,6 +70,7 @@
         "vitest": "^4.0.4"
       },
       "peerDependencies": {
+        "bootstrap": "^5.3.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -42,10 +42,8 @@
   "sideEffects": [
     "**/*.css"
   ],
-  "dependencies": {
-    "bootstrap": "^5.3.8"
-  },
   "peerDependencies": {
+    "bootstrap": "^5.3.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },


### PR DESCRIPTION
## Description

This PR moves Bootstrap from runtime dependency metadata to peer dependency metadata, and documents the supported Bootstrap compatibility range for this package line.

Changes included in the latest commit:
- Move Bootstrap from dependencies to peerDependencies in package metadata
- Keep Bootstrap in devDependencies for local development workflows
- Update lockfile to match dependency metadata changes
- Add README compatibility guidance explaining that coupling is via Bootstrap CSS class names, not Bootstrap JavaScript runtime

Motivation:
- Make Bootstrap version coupling explicit for consumers
- Align dependency declaration with Moodle LMS changes around Bootstrap declaration and upgrades
- Reduce ambiguity about runtime JavaScript dependency expectations

## Related Jira or GitHub Issue

- https://moodle.atlassian.net/browse/MDS-596
- https://moodle.atlassian.net/browse/MDS-612

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [x] Other (dependency metadata update)

## Screenshots/Previews

N/A. No component UI behavior or visual output changes.

## Checklist

- [ ] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

- This is a metadata and documentation scoped update; no component implementation changes are included.
- Bootstrap remains in devDependencies to support local tooling and development workflows.