### PR TITLE
fix(Radio, Checkbox): Fix alignment issues

### DIFF
--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -324,9 +324,7 @@ All MDS components must use `outline` + `outline-offset` for focus rings — **n
 }
 .mds-component:focus-visible {
   outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
-  outline-offset: var(
-    --mds-stroke-weight-sm
-  ); /* replace with --mds-focus-ring-offset once token is created */
+  outline-offset: var(--mds-spacing-offset);
   box-shadow: none;
 }
 ```
@@ -336,7 +334,7 @@ For components with an error/invalid state, use the danger border token for the 
 ```css
 .mds-component.is-invalid:focus-visible {
   outline: var(--mds-stroke-weight-md) solid var(--mds-border-feedback-danger);
-  outline-offset: var(--mds-stroke-weight-sm);
+  outline-offset: var(--mds-spacing-offset);
   box-shadow: none;
 }
 ```
@@ -346,4 +344,3 @@ For components with an error/invalid state, use the danger border token for the 
 - Do not use `box-shadow` or `border` to implement focus rings. The double-layer shadow pattern (`0 0 0 Xpx surface-colour, 0 0 0 Ypx focus-colour`) is Bootstrap's approach and must not be reintroduced. Figma handoff data may also suggest border-based focus rings — these must not be used.
 - Do not suppress `outline` on `:focus-visible` — setting `outline: none` on this selector removes the ring entirely.
 - The `box-shadow: none` reset on `:focus-visible` is required to neutralise any Bootstrap shadow that may be applied by the `:focus` cascade.
-- Once `--mds-focus-ring-offset` is added to the token library, replace all interim `var(--mds-stroke-weight-sm)` usages in `outline-offset` with it.

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -182,7 +182,7 @@ For components built on a Bootstrap base class (e.g. `btn`): include the Bootstr
 
 For components not built on Bootstrap: the `mds-*` hook is still required; omit Bootstrap classes entirely.
 
-**Apply an `mds-*` hook class to every element that has component-scoped CSS rules**, not just the root. This allows consumers and the CSS to target any element directly without relying on descendant selectors alone. For example, a component with a wrapper, an input, a label, and a feedback element should apply `mds-form-check`, `mds-form-check-input`, `mds-form-check-label`, and `mds-form-check-feedback` respectively. Bootstrap classes are applied alongside the `mds-*` hooks where needed for base styling.
+**Apply an `mds-*` hook class to every element that has component-scoped CSS rules**, not just the root. This allows consumers and the CSS to target any element directly without relying on descendant selectors alone. For example, a component with a wrapper, an input, a label, and a feedback element should apply `mds-radio`, `mds-radio-input`, `mds-radio-label`, and `mds-radio-feedback` respectively. Bootstrap classes are applied alongside the `mds-*` hooks where needed for base styling.
 
 ```tsx
 // Example: component with Bootstrap base

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -31,7 +31,7 @@
 /* All components — default focus ring */
 .mds-btn.btn.pseudo-focus-visible,
 .mds-checkbox-input.pseudo-focus-visible,
-.mds-form-check-input.pseudo-focus-visible,
+.mds-radio-input.pseudo-focus-visible,
 .mds-pagination__button.pseudo-focus-visible:not(:disabled),
 .mds-pagination__page.pseudo-focus-visible:not(:disabled) {
   outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
@@ -55,6 +55,6 @@
 
 /* Checkbox / radio invalid — outline color override */
 .mds-checkbox-input.is-invalid.pseudo-focus-visible,
-.mds-form-check-input.is-invalid.pseudo-focus-visible {
+.mds-radio-input.is-invalid.pseudo-focus-visible {
   outline-color: var(--mds-border-feedback-danger);
 }

--- a/components/checkbox/Checkbox.stories.tsx
+++ b/components/checkbox/Checkbox.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { useArgs } from 'storybook/preview-api';
 import { expect, waitFor } from 'storybook/test';
 import { Checkbox } from './Checkbox';
 
@@ -32,6 +34,7 @@ const meta = {
       control: { type: 'text' },
       description:
         'Accessible label for the input. Takes precedence over the label prop when hideLabel is true. Required when hideLabel is true and no label prop is provided.',
+      if: { arg: 'hideLabel', truthy: true },
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: '' },
@@ -39,12 +42,23 @@ const meta = {
     },
     checked: {
       control: { type: 'boolean' },
-      description: 'Whether the checkbox input is checked in controlled mode.',
+      description:
+        'Whether the checkbox input is checked (controlled mode). Use checked together with an onChange handler to keep the component interactive.',
       table: {
         type: {
           summary: 'true | false',
         },
         defaultValue: { summary: 'false' },
+      },
+    },
+    onChange: {
+      control: false,
+      description:
+        'Change handler for controlled usage. When checked is provided, onChange is required unless readOnly is true.',
+      table: {
+        type: {
+          summary: '(event: React.ChangeEvent<HTMLInputElement>) => void',
+        },
       },
     },
     indeterminate: {
@@ -76,6 +90,16 @@ const meta = {
         defaultValue: { summary: 'false' },
       },
     },
+    invalidFeedback: {
+      control: { type: 'text' },
+      description:
+        'Pre-translated error message shown below the label when the input is invalid. Requires invalid={true} to be set.',
+      if: { arg: 'invalid', truthy: true },
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
     required: {
       control: { type: 'boolean' },
       description:
@@ -85,14 +109,6 @@ const meta = {
           summary: 'true | false',
         },
         defaultValue: { summary: 'false' },
-      },
-    },
-    invalidFeedback: {
-      description:
-        'Pre-translated error message shown below the label when the input is invalid. Requires invalid={true} to be set.',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: 'undefined' },
       },
     },
     supportingText: {
@@ -143,15 +159,6 @@ const meta = {
         defaultValue: { summary: 'false' },
       },
     },
-    className: {
-      control: { type: 'text' },
-      description:
-        'Additional class names to apply to the checkbox wrapper div for custom styling.',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: '' },
-      },
-    },
   },
   args: {
     label: 'Remember this setting',
@@ -161,9 +168,9 @@ const meta = {
     indeterminate: false,
     disabled: false,
     invalid: false,
+    invalidFeedback: undefined,
     required: false,
     autoFocus: false,
-    defaultChecked: false,
   },
 } satisfies Meta<typeof Checkbox>;
 
@@ -172,22 +179,72 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default = {
+  args: {
+    checked: false,
+  },
+  render: function Render(args) {
+    const [{ checked }, updateArgs] = useArgs<typeof args>();
+
+    return (
+      <Checkbox
+        {...args}
+        checked={checked}
+        onChange={(event) => {
+          updateArgs({ checked: event.target.checked });
+        }}
+      />
+    );
+  },
   play: async ({ canvas, userEvent }) => {
     const checkbox = canvas.getByRole('checkbox', {
       name: 'Remember this setting',
     });
     await userEvent.click(checkbox);
-    await expect(checkbox).toBeChecked();
-    await userEvent.click(checkbox);
-    await expect(checkbox).not.toBeChecked();
+    await waitFor(() => {
+      expect(
+        canvas.getByRole('checkbox', { name: 'Remember this setting' }),
+      ).toBeVisible();
+    });
+    await userEvent.click(
+      canvas.getByRole('checkbox', {
+        name: 'Remember this setting',
+      }),
+    );
     // Return to a neutral visual baseline so screenshot QA is not biased by focus styling.
-    checkbox.blur();
-    await expect(checkbox).not.toHaveFocus();
+    const currentCheckbox = canvas.getByRole('checkbox', {
+      name: 'Remember this setting',
+    });
+    currentCheckbox.blur();
+    await expect(currentCheckbox).not.toHaveFocus();
     await expect(canvas.getByText('Remember this setting')).toBeVisible();
   },
 } satisfies Story;
 
+/**
+ * Uncontrolled checked checkbox example.
+ *
+ * This story demonstrates the use of `defaultChecked` for an uncontrolled checkbox input.
+ * The checked state is managed by the DOM, not React state. Use this for simple forms where you do not need to track the checked state in React.
+ */
+
 export const DefaultChecked: Story = {
+  name: 'Uncontrolled checked',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { Checkbox } from '@moodlehq/design-system';
+
+export const DefaultCheckedExample = () => (
+  <Checkbox
+    label="Remember this setting"
+    name="settings"
+    value="remember-this-setting"
+    defaultChecked
+  />
+);`,
+      },
+    },
+  },
   args: {
     defaultChecked: true,
   },
@@ -198,15 +255,64 @@ export const DefaultChecked: Story = {
   },
 };
 
+/**
+ * Controlled checked checkbox example.
+ *
+ * This story demonstrates the use of `checked` and `onChange` for a controlled checkbox input.
+ * The checked state is managed by React state. Use this pattern when you need to track or update the checked state in your component logic.
+ */
+
 export const ControlledChecked: Story = {
+  name: 'Controlled checked',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { useState } from 'react';
+import { Checkbox } from '@moodlehq/design-system';
+
+export const ControlledCheckedExample = () => {
+  const [checked, setChecked] = useState(false);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+  };
+
+  return (
+    <Checkbox
+      label="Remember this setting"
+      name="settings"
+      value="remember-this-setting"
+      checked={checked}
+      onChange={handleChange}
+    />
+  );
+};`,
+      },
+    },
+  },
   args: {
     checked: true,
-    onChange: () => {},
   },
-  play: async ({ canvas }) => {
-    await expect(
-      canvas.getByRole('checkbox', { name: 'Remember this setting' }),
-    ).toBeChecked();
+  render: function Render(args) {
+    const [checked, setChecked] = useState<boolean>(!!args.checked);
+
+    return (
+      <Checkbox
+        {...args}
+        checked={checked}
+        onChange={(event) => setChecked(event.target.checked)}
+      />
+    );
+  },
+  play: async ({ canvas, userEvent }) => {
+    const checkbox = canvas.getByRole('checkbox', {
+      name: 'Remember this setting',
+    });
+    await expect(checkbox).toBeChecked();
+    await userEvent.click(checkbox);
+    await expect(checkbox).not.toBeChecked();
+    await userEvent.click(checkbox);
+    await expect(checkbox).toBeChecked();
   },
 };
 

--- a/components/checkbox/Checkbox.stories.tsx
+++ b/components/checkbox/Checkbox.stories.tsx
@@ -259,6 +259,39 @@ export const SupportingText: Story = {
   },
 };
 
+export const WrappedLabel: Story = {
+  render: (args) => (
+    <div style={{ width: '14rem' }}>
+      <Checkbox {...args} />
+    </div>
+  ),
+  args: {
+    required: true,
+    label:
+      'Remember this setting so the label wraps naturally when the available viewport width is too small for a single line',
+    supportingText:
+      'This helper text should also wrap cleanly when the viewport is narrow.',
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole('checkbox', {
+        name: 'Remember this setting so the label wraps naturally when the available viewport width is too small for a single line',
+      }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByText(
+        'Remember this setting so the label wraps naturally when the available viewport width is too small for a single line',
+      ),
+    ).toBeVisible();
+    await expect(
+      canvas.getByText(
+        'This helper text should also wrap cleanly when the viewport is narrow.',
+      ),
+    ).toBeVisible();
+    await expect(canvas.getByText('*')).toBeVisible();
+  },
+} satisfies Story;
+
 export const Indeterminate: Story = {
   args: {
     indeterminate: true,

--- a/components/checkbox/Checkbox.test.tsx
+++ b/components/checkbox/Checkbox.test.tsx
@@ -143,6 +143,26 @@ describe('Checkbox: Unit Test', () => {
       expect(screen.getByText('Helper copy')).toBeInTheDocument();
     });
 
+    it('renders supporting text when disabled, even if invalid feedback is also provided', () => {
+      render(
+        <Checkbox
+          id="disabled-supporting-checkbox"
+          label="Option"
+          disabled
+          supportingText="Helper copy"
+          invalid
+          invalidFeedback="Required"
+        />,
+      );
+
+      expect(screen.getByText('Helper copy')).toBeInTheDocument();
+      expect(screen.queryByText('Required')).not.toBeInTheDocument();
+      expect(screen.getByRole('checkbox')).toHaveAttribute(
+        'aria-describedby',
+        'disabled-supporting-checkbox-feedback',
+      );
+    });
+
     it('sets aria-describedby to supporting text when no invalid feedback is active', () => {
       render(
         <Checkbox
@@ -236,6 +256,17 @@ describe('Checkbox: Unit Test', () => {
       expect(screen.getByRole('checkbox')).toHaveAttribute(
         'aria-describedby',
         'test-checkbox-feedback',
+      );
+    });
+
+    it('does not render invalid feedback when disabled', () => {
+      render(
+        <Checkbox label="Option" disabled invalid invalidFeedback="Required" />,
+      );
+
+      expect(screen.queryByText('Required')).not.toBeInTheDocument();
+      expect(screen.getByRole('checkbox')).not.toHaveAttribute(
+        'aria-describedby',
       );
     });
 

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -17,15 +17,15 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   /** Marks the input as invalid: applies danger border/label colour and sets aria-invalid.
    *  Independent of invalidFeedback — invalid styling can be shown without a message. */
   invalid?: boolean;
+  /** Pre-translated error message rendered below the label. Requires invalid={true} and
+   *  hideLabel={false} to be displayed. */
+  invalidFeedback?: string;
   /** Renders the checkbox in a mixed state, typically for "select all" parent controls.
    *  This state is visual/semantic and should usually be controlled by parent logic. */
   indeterminate?: boolean;
   /** Optional supporting/helper text shown below the label in non-error state.
    *  Hidden when hideLabel is true. */
   supportingText?: string;
-  /** Pre-translated error message rendered below the label. Requires invalid={true} and
-   *  hideLabel={false} to be displayed. */
-  invalidFeedback?: string;
 }
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -40,6 +40,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       hideLabel = false,
       id: idProp,
       required,
+      disabled,
       'aria-label': ariaLabelProp,
       ...inputProps
     }: CheckboxProps,
@@ -49,6 +50,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const id = idProp ?? generatedId;
     const hasVisibleLabel = !hideLabel;
     const isInvalid = !!invalid;
+    const isDisabled = !!disabled;
     const isIndeterminate = !!indeterminate;
     const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -89,42 +91,45 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
     const ariaLabel = hideLabel ? (ariaLabelProp ?? label) : undefined;
     const messageText = hasVisibleLabel
-      ? isInvalid && invalidFeedback
+      ? isInvalid && !isDisabled && invalidFeedback
         ? invalidFeedback
         : supportingText
       : undefined;
     const hasInvalidFeedback =
-      hasVisibleLabel && isInvalid && !!invalidFeedback;
+      hasVisibleLabel && isInvalid && !isDisabled && !!invalidFeedback;
     const feedbackId = messageText ? `${id}-feedback` : undefined;
 
     return (
       <div className={classes.join(' ')}>
-        <input
-          className={[
-            'mds-checkbox-input',
-            'form-check-input',
-            isInvalid ? 'is-invalid' : '',
-          ]
-            .filter(Boolean)
-            .join(' ')}
-          ref={(node) => {
-            // Keep a local ref for the native indeterminate property while still forwarding refs.
-            inputRef.current = node;
-            if (typeof ref === 'function') {
-              ref(node);
-            } else if (ref) {
-              ref.current = node;
-            }
-          }}
-          {...inputProps}
-          type="checkbox"
-          required={required}
-          aria-invalid={isInvalid ? true : undefined}
-          aria-label={ariaLabel}
-          aria-checked={isIndeterminate ? 'mixed' : undefined}
-          aria-describedby={feedbackId}
-          id={id}
-        />
+        <div className="mds-checkbox-input-wrapper">
+          <input
+            className={[
+              'mds-checkbox-input',
+              'form-check-input',
+              isInvalid ? 'is-invalid' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            ref={(node) => {
+              // Keep a local ref for the native indeterminate property while still forwarding refs.
+              inputRef.current = node;
+              if (typeof ref === 'function') {
+                ref(node);
+              } else if (ref) {
+                ref.current = node;
+              }
+            }}
+            {...inputProps}
+            type="checkbox"
+            required={required}
+            disabled={disabled}
+            aria-invalid={isInvalid ? true : undefined}
+            aria-label={ariaLabel}
+            aria-checked={isIndeterminate ? 'mixed' : undefined}
+            aria-describedby={feedbackId}
+            id={id}
+          />
+        </div>
         {hasVisibleLabel && (
           <label className="mds-checkbox-label form-check-label" htmlFor={id}>
             <span className="mds-checkbox-label-text">{label}</span>

--- a/components/checkbox/checkbox.css
+++ b/components/checkbox/checkbox.css
@@ -1,9 +1,9 @@
-.mds-checkbox {
+/* Use [class] to outrank Bootstrap selectors like .form-check .form-check-input */
+.mds-checkbox[class] {
   display: inline-grid;
   grid-template-columns: auto auto;
-  align-items: center;
+  align-items: start;
   align-self: start;
-  min-height: var(--mds-icons-lg);
   padding: var(--mds-spacing-none);
   column-gap: var(--mds-spacing-xs);
   row-gap: var(--mds-spacing-xxs);
@@ -11,17 +11,24 @@
   font-family: var(--mds-font-family-base);
   font-size: var(--mds-font-size-paragraph-default);
   font-weight: var(--mds-font-weight-regular);
-  line-height: var(--mds-line-height-paragraph-xs);
+  line-height: var(--mds-line-height-paragraph-default);
   letter-spacing: var(--mds-letter-spacing-default);
 }
 
-.mds-checkbox-input {
+/* Touch-target wrapper: enforces the Figma minimum height and vertically centres the
+   indicator within it so it optically aligns with the first line of a wrapped label. */
+.mds-checkbox[class] .mds-checkbox-input-wrapper {
+  display: flex;
+  align-items: center;
+  min-height: 24px;
+}
+
+.mds-checkbox[class] .mds-checkbox-input {
   border-radius: var(--mds-border-radius-xs);
   border: var(--mds-stroke-weight-sm) solid
     var(--mds-border-interactive-secondary-default);
-}
-
-.mds-checkbox .mds-checkbox-input {
+  /* Disable Bootstrap's state transitions to avoid a one-frame focus colour flash. */
+  transition: none;
   /* Bootstrap applies float/offset styles to .form-check-input for indented label layouts.
      Match selector specificity and reset float/margins for the grid-based sibling layout. */
   margin: 0;
@@ -29,61 +36,42 @@
   background-color: var(--mds-bg-surface-default);
 }
 
-.mds-checkbox-input:checked {
+.mds-checkbox[class] .mds-checkbox-input:is(:checked, :indeterminate) {
   background-color: var(--mds-bg-interactive-primary-default);
   border-color: transparent;
 }
 
-.mds-checkbox-input:indeterminate {
-  background-color: var(--mds-bg-interactive-primary-default);
-  border-color: transparent;
-}
-
-.mds-checkbox-input:disabled {
+.mds-checkbox[class] .mds-checkbox-input:disabled {
   border-color: var(--mds-border-interactive-secondary-disabled);
 }
 
-.mds-checkbox-input:disabled:checked {
+.mds-checkbox[class] .mds-checkbox-input:disabled:is(:checked, :indeterminate) {
   background-color: var(--mds-bg-interactive-primary-disabled);
   border-color: transparent;
 }
 
-.mds-checkbox-input:disabled:indeterminate {
-  background-color: var(--mds-bg-interactive-primary-disabled);
-  border-color: transparent;
-}
-
-.mds-checkbox-input.is-invalid {
+.mds-checkbox[class] .mds-checkbox-input.is-invalid {
   border-color: var(--mds-border-interactive-danger-default);
 }
 
-.mds-checkbox-input.is-invalid:checked {
+.mds-checkbox[class]
+  .mds-checkbox-input.is-invalid:is(:checked, :indeterminate) {
   background-color: var(--mds-bg-interactive-danger-default);
   border-color: transparent;
 }
 
-.mds-checkbox-input.is-invalid:indeterminate {
-  background-color: var(--mds-bg-interactive-danger-default);
-  border-color: transparent;
-}
-
-.mds-checkbox-input.is-invalid:disabled {
+.mds-checkbox[class] .mds-checkbox-input.is-invalid:disabled {
   background-color: var(--mds-bg-interactive-secondary-disabled);
   border-color: var(--mds-border-interactive-secondary-disabled);
 }
 
-.mds-checkbox-input.is-invalid:disabled:checked {
+.mds-checkbox[class]
+  .mds-checkbox-input.is-invalid:disabled:is(:checked, :indeterminate) {
   background-color: var(--mds-bg-interactive-primary-disabled);
   border-color: transparent;
 }
 
-.mds-checkbox-input.is-invalid:disabled:indeterminate {
-  background-color: var(--mds-bg-interactive-primary-disabled);
-  border-color: transparent;
-}
-
-.mds-checkbox-input:focus,
-.mds-checkbox-input.is-invalid:focus {
+.mds-checkbox[class] .mds-checkbox-input:focus {
   /* Reset Bootstrap's :focus box-shadow; our ring is applied on :focus-visible only */
   box-shadow: none;
   outline: none;
@@ -91,91 +79,90 @@
 
 /* Bootstrap also sets border-color on :focus. Restore the correct border for each state,
    excluding checked/indeterminate which keep their transparent border. */
-.mds-checkbox-input:focus:not(:checked):not(:indeterminate) {
+.mds-checkbox[class]
+  .mds-checkbox-input:focus:not(:checked):not(:indeterminate) {
   border-color: var(--mds-border-interactive-secondary-default);
 }
 
-.mds-checkbox-input.is-invalid:focus:not(:checked):not(:indeterminate) {
+.mds-checkbox[class]
+  .mds-checkbox-input.is-invalid:focus:not(:checked):not(:indeterminate) {
   border-color: var(--mds-border-interactive-danger-default);
 }
 
-.mds-checkbox-input:focus-visible {
+.mds-checkbox[class] .mds-checkbox-input:focus-visible {
   outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
   outline-offset: var(--mds-spacing-offset);
   box-shadow: none;
 }
 
-.mds-checkbox-input.is-invalid:focus-visible {
+.mds-checkbox[class] .mds-checkbox-input.is-invalid:focus-visible {
   outline: var(--mds-stroke-weight-md) solid var(--mds-border-feedback-danger);
   outline-offset: var(--mds-spacing-offset);
   box-shadow: none;
 }
 
-.mds-checkbox .form-check-label,
-.mds-checkbox .mds-checkbox-label {
-  display: flex;
-  align-items: center;
+.mds-checkbox[class] .mds-checkbox-label {
   /* In the radio-style sibling layout, the checkbox should align to the label text line,
      not to an expanded label hit area. Keep the label box tight and let htmlFor preserve click behavior. */
   padding: 0;
   color: var(--mds-text-default);
 }
 
-.mds-checkbox .mds-checkbox-label-text {
-  min-width: 0;
-}
-
-.mds-checkbox .mds-checkbox-input:disabled ~ .form-check-label,
-.mds-checkbox .mds-checkbox-input:disabled ~ .mds-checkbox-label {
+.mds-checkbox[class]
+  .mds-checkbox-input-wrapper:has(:disabled)
+  ~ .mds-checkbox-label {
   color: var(--mds-text-muted);
 }
 
-.mds-checkbox .mds-checkbox-input.is-invalid ~ .form-check-label,
-.mds-checkbox .mds-checkbox-input.is-invalid ~ .mds-checkbox-label {
+.mds-checkbox[class]
+  .mds-checkbox-input-wrapper:has(.is-invalid)
+  ~ .mds-checkbox-label {
   color: var(--mds-text-danger);
 }
 
 /* Disabled takes precedence over invalid — restore muted colour when both are active. */
-.mds-checkbox .mds-checkbox-input.is-invalid:disabled ~ .form-check-label,
-.mds-checkbox .mds-checkbox-input.is-invalid:disabled ~ .mds-checkbox-label {
+.mds-checkbox[class]
+  .mds-checkbox-input-wrapper:has(.is-invalid:disabled)
+  ~ .mds-checkbox-label {
   color: var(--mds-text-muted);
 }
 
-.mds-checkbox-required {
+.mds-checkbox[class] .mds-checkbox-required {
   color: var(--mds-text-danger);
   margin-inline-start: var(--mds-spacing-xxs);
 }
 
-.mds-checkbox .invalid-feedback,
-.mds-checkbox .mds-checkbox-feedback {
+.mds-checkbox[class] .mds-checkbox-feedback {
+  /* Bootstrap hides .invalid-feedback via display:none and reveals it with an .is-invalid
+     sibling selector. The input is now inside .mds-checkbox-input-wrapper so that selector
+     no longer reaches the feedback div. Override here — we control rendering in JSX. */
+  display: block;
   grid-column: 2;
-  font-size: var(--mds-font-size-paragraph-small);
-  font-weight: var(--mds-font-weight-medium);
-  line-height: var(--mds-line-height-paragraph-xs);
-}
-
-.mds-checkbox .invalid-feedback,
-.mds-checkbox .mds-checkbox-feedback.mds-checkbox-supporting-text {
   margin: 0;
+  font-size: var(--mds-font-size-paragraph-small);
+  font-weight: var(--mds-font-weight-regular);
+  line-height: var(--mds-line-height-paragraph-small);
 }
 
-.mds-checkbox .invalid-feedback {
+/* Invalid feedback is explicitly danger-coloured. */
+.mds-checkbox[class] .mds-checkbox-feedback.invalid-feedback {
   color: var(--mds-text-danger);
 }
 
-/* In the default state supporting text is subtle. In the invalid state use danger to match
-   the label colour \u2014 matching Figma where the label container sets the colour for both. */
-.mds-checkbox .mds-checkbox-feedback.mds-checkbox-supporting-text {
+/* Supporting text is subtle by default. */
+.mds-checkbox[class] .mds-checkbox-feedback.mds-checkbox-supporting-text {
   color: var(--mds-text-subtle);
 }
 
-.mds-checkbox
-  .mds-checkbox-input.is-invalid
+/* Supporting text is danger-coloured when invalid (not disabled) to match the .mds-checkbox-label */
+.mds-checkbox[class]
+  .mds-checkbox-input-wrapper:has(.is-invalid:not(:disabled))
   ~ .mds-checkbox-feedback.mds-checkbox-supporting-text {
   color: var(--mds-text-danger);
 }
 
-.mds-checkbox .mds-checkbox-input:disabled ~ .invalid-feedback,
-.mds-checkbox .mds-checkbox-input:disabled ~ .mds-checkbox-feedback {
+.mds-checkbox[class]
+  .mds-checkbox-input-wrapper:has(:disabled)
+  ~ .mds-checkbox-feedback {
   opacity: 0.5;
 }

--- a/components/radio/Radio.stories.tsx
+++ b/components/radio/Radio.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { useArgs } from 'storybook/preview-api';
 import { expect } from 'storybook/test';
 import { Radio } from './Radio';
 
@@ -35,12 +37,23 @@ const meta = {
     },
     checked: {
       control: { type: 'boolean' },
-      description: 'Whether the radio input is checked (controlled mode).',
+      description:
+        'Whether the radio input is checked (controlled mode). Use checked together with an onChange handler to keep the component interactive.',
       table: {
         type: {
           summary: 'true | false',
         },
         defaultValue: { summary: 'false' },
+      },
+    },
+    onChange: {
+      control: false,
+      description:
+        'Change handler for controlled usage. When checked is provided, onChange is required unless readOnly is true.',
+      table: {
+        type: {
+          summary: '(event: React.ChangeEvent<HTMLInputElement>) => void',
+        },
       },
     },
     required: {
@@ -75,6 +88,7 @@ const meta = {
       },
     },
     label: {
+      control: { type: 'text' },
       description:
         'Visible label text. Also used as the aria-label fallback when hideLabel is true and no explicit aria-label is provided.',
       table: {
@@ -82,8 +96,10 @@ const meta = {
       },
     },
     ['aria-label']: {
+      control: { type: 'text' },
       description:
         'Accessible label for the input. Takes precedence over the label prop when hideLabel is true. Required when hideLabel is true and no label prop is provided.',
+      if: { arg: 'hideLabel', truthy: true },
       table: {
         defaultValue: { summary: '' },
       },
@@ -99,16 +115,11 @@ const meta = {
         defaultValue: { summary: 'false' },
       },
     },
-    className: {
-      description:
-        'Additional class names to apply to the radio wrapper div for custom styling when displaying the radio input with a label.',
-      table: {
-        defaultValue: { summary: '' },
-      },
-    },
     invalidFeedback: {
+      control: { type: 'text' },
       description:
         'Pre-translated error message shown below the label when the input is invalid. Requires invalid={true} to be set. The caller is responsible for supplying a translated string.',
+      if: { arg: 'invalid', truthy: true },
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: 'undefined' },
@@ -133,7 +144,6 @@ const meta = {
     hideLabel: false,
     label: 'Email',
     autoFocus: false,
-    className: undefined,
     invalidFeedback: undefined,
     // Uncontrolled by default; no checked/onChange
   },
@@ -148,18 +158,28 @@ type Story = StoryObj<typeof meta>;
  * Default unselected state. Clicking the input or label selects it.
  */
 export const Default = {
-  play: async ({ canvas, userEvent }) => {
+  args: {
+    checked: false,
+  },
+  render: function Render(args) {
+    const [{ checked }, updateArgs] = useArgs<typeof args>();
+
+    return (
+      <Radio
+        {...args}
+        checked={checked}
+        onChange={(event) => {
+          updateArgs({ checked: event.target.checked });
+        }}
+      />
+    );
+  },
+  play: async ({ canvas }) => {
     const radio = canvas.getByRole('radio', { name: 'Email' });
-    await userEvent.click(radio);
-    await expect(radio).toBeChecked();
+    await expect(radio).not.toBeChecked();
     await expect(canvas.getByText('Email')).toBeVisible();
   },
 } satisfies Story;
-
-/**
- * Pre-checked on render via `defaultChecked`. Use `defaultChecked` for uncontrolled
- * forms and `checked` together with an `onChange` handler for controlled forms.
- */
 
 /**
  * Uncontrolled checked radio example.
@@ -167,7 +187,24 @@ export const Default = {
  * This story demonstrates the use of `defaultChecked` for an uncontrolled radio input.
  * The checked state is managed by the DOM, not React state. Use this for simple forms where you do not need to track the checked state in React.
  */
-export const Checked: Story = {
+export const DefaultChecked: Story = {
+  name: 'Uncontrolled checked',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { Radio } from '@moodlehq/design-system';
+
+export const DefaultCheckedExample = () => (
+  <Radio
+    label="Email"
+    name="contact-method"
+    value="email"
+    defaultChecked
+  />
+);`,
+      },
+    },
+  },
   args: {
     name: 'contact-checked',
     defaultChecked: true,
@@ -184,10 +221,43 @@ export const Checked: Story = {
  * The checked state is managed by React state. Use this pattern when you need to track or update the checked state in your component logic.
  */
 export const ControlledChecked: Story = {
+  name: 'Controlled checked',
+  parameters: {
+    docs: {
+      source: {
+        code: `import { useState } from 'react';
+import { Radio } from '@moodlehq/design-system';
+
+export const ControlledCheckedExample = () => {
+  const [selected, setSelected] = useState<string | undefined>(undefined);
+
+  return (
+    <Radio
+      label="Email"
+      name="contact-method"
+      value="email"
+      checked={selected === 'email'}
+      onChange={(event) => setSelected(event.target.value)}
+    />
+  );
+};`,
+      },
+    },
+  },
   args: {
     name: 'contact-controlled',
     checked: true,
-    onChange: () => {},
+  },
+  render: function Render(args) {
+    const [checked, setChecked] = useState<boolean>(!!args.checked);
+
+    return (
+      <Radio
+        {...args}
+        checked={checked}
+        onChange={(event) => setChecked(event.target.checked)}
+      />
+    );
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('radio', { name: 'Email' })).toBeChecked();

--- a/components/radio/Radio.stories.tsx
+++ b/components/radio/Radio.stories.tsx
@@ -381,6 +381,30 @@ export const HideLabelFallback: Story = {
 };
 
 /**
+ * When the label text wraps to multiple lines, the radio indicator stays pinned to the
+ * top and aligns with the first line — matching the checkbox behaviour.
+ */
+export const WrappedLabel: Story = {
+  render: (args) => (
+    <div style={{ width: '14rem' }}>
+      <Radio {...args} />
+    </div>
+  ),
+  args: {
+    name: 'contact-wrapped',
+    label:
+      'Select this option so the label wraps naturally when the available viewport width is too small for a single line',
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole('radio', {
+        name: 'Select this option so the label wraps naturally when the available viewport width is too small for a single line',
+      }),
+    ).toBeVisible();
+  },
+} satisfies Story;
+
+/**
  * Keyboard interaction: Tab to focus the input, then Space to select it.
  */
 export const KeyboardInteraction: Story = {

--- a/components/radio/Radio.test.tsx
+++ b/components/radio/Radio.test.tsx
@@ -6,9 +6,9 @@ import { fuzzComponent } from '../../tests/utils/fuzzComponent';
 import { type RadioProps, Radio } from './Radio';
 
 describe('Radio: Unit Test', () => {
-  it('applies mds-form-check class to the root wrapper element', () => {
+  it('applies mds-radio class to the root wrapper element', () => {
     const { container } = render(<Radio label="Option" />);
-    expect(container.firstChild).toHaveClass('mds-form-check');
+    expect(container.firstChild).toHaveClass('mds-radio');
   });
 
   it('applies form-check class to the wrapper when hideLabel is false', () => {
@@ -21,9 +21,9 @@ describe('Radio: Unit Test', () => {
     expect(container.firstChild).not.toHaveClass('form-check');
   });
 
-  it('applies mds-form-check-input class to the input', () => {
+  it('applies mds-radio-input class to the input', () => {
     render(<Radio label="Option" />);
-    expect(screen.getByRole('radio')).toHaveClass('mds-form-check-input');
+    expect(screen.getByRole('radio')).toHaveClass('mds-radio-input');
   });
 
   it('renders the label text', () => {
@@ -224,9 +224,9 @@ describe('Radio: Unit Test', () => {
       vi.restoreAllMocks();
     });
 
-    it('applies mds-form-check class to the wrapper even when hideLabel is true', () => {
+    it('applies mds-radio class to the wrapper even when hideLabel is true', () => {
       const { container } = render(<Radio label="Option" hideLabel />);
-      expect(container.firstChild).toHaveClass('mds-form-check');
+      expect(container.firstChild).toHaveClass('mds-radio');
     });
   });
 

--- a/components/radio/Radio.tsx
+++ b/components/radio/Radio.tsx
@@ -30,6 +30,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
       className,
       label,
       hideLabel = false,
+      disabled,
       ...props
     }: RadioProps,
     ref,
@@ -64,10 +65,11 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
         );
       }
     }
+
     // Build the class list for the radio wrapper div. mds-form-check is always applied
     // as a stable hook for consumers; form-check and layout classes are added only when
     // the label is visible (Bootstrap label/feedback styling and grid layout).
-    const classes = ['mds-form-check'];
+    const classes = ['mds-radio'];
     if (!hideLabel) {
       classes.push('form-check');
     }
@@ -81,36 +83,38 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
     // Link the input to its feedback text so screen readers announce the error message.
     // The ID is only generated when feedback will actually be rendered.
     const feedbackId =
-      invalidFeedback && !hideLabel && invalid ? `${id}-feedback` : undefined;
+      invalidFeedback && !hideLabel && invalid && !disabled
+        ? `${id}-feedback`
+        : undefined;
 
     return (
       <div className={classes.join(' ')}>
-        <input
-          className={[
-            'mds-form-check-input',
-            'form-check-input',
-            isInvalid ? 'is-invalid' : '',
-          ]
-            .filter(Boolean)
-            .join(' ')}
-          type="radio"
-          ref={ref}
-          {...props}
-          aria-invalid={isInvalid ? true : undefined}
-          aria-label={ariaLabel}
-          aria-describedby={feedbackId}
-          id={id} // Ensure we use the generated ID if no ID is provided, so the label can be properly associated with the input for accessibility.
-        />
+        <div className="mds-radio-input-wrapper">
+          <input
+            className={[
+              'mds-radio-input',
+              'form-check-input',
+              isInvalid ? 'is-invalid' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            type="radio"
+            ref={ref}
+            {...props}
+            disabled={disabled}
+            aria-invalid={isInvalid ? true : undefined}
+            aria-label={ariaLabel}
+            aria-describedby={feedbackId}
+            id={id} // Ensure we use the generated ID if no ID is provided, so the label can be properly associated with the input for accessibility.
+          />
+        </div>
         {!hideLabel && (
-          <label className="mds-form-check-label form-check-label" htmlFor={id}>
+          <label className="mds-radio-label form-check-label" htmlFor={id}>
             {label}
           </label>
         )}
         {feedbackId && (
-          <div
-            id={feedbackId}
-            className="mds-form-check-feedback invalid-feedback"
-          >
+          <div id={feedbackId} className="mds-radio-feedback invalid-feedback">
             {invalidFeedback}
           </div>
         )}

--- a/components/radio/Radio.tsx
+++ b/components/radio/Radio.tsx
@@ -66,7 +66,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
       }
     }
 
-    // Build the class list for the radio wrapper div. mds-form-check is always applied
+    // Build the class list for the radio wrapper div. mds-radio is always applied
     // as a stable hook for consumers; form-check and layout classes are added only when
     // the label is visible (Bootstrap label/feedback styling and grid layout).
     const classes = ['mds-radio'];

--- a/components/radio/radio.css
+++ b/components/radio/radio.css
@@ -1,133 +1,117 @@
-/* Parent element */
-.mds-form-check {
-  /* Grid layout: column 1 = input, column 2 = label. The feedback is then placed
-     explicitly into column 2 via grid-column so it aligns with the label without
-     requiring any offset calculation. Grid formatting context also suppresses
-     Bootstrap's float on the input child. */
+/* Use [class] to outrank Bootstrap selectors like .form-check .form-check-input */
+.mds-radio[class] {
+  /* Grid keeps feedback aligned under the label without Bootstrap's offset layout. */
   display: inline-grid;
   grid-template-columns: auto auto;
   align-items: start;
-  /* Prevent flex containers from stretching this element across the cross axis,
-     which would widen the grid and split the two auto columns equally, pushing
-     the label away from the input. start preserves content-sized behaviour. */
   align-self: start;
-  /* min-height matches the icon-lg token (24px) so the wrapper never collapses
-     below the height of the radio indicator, regardless of label content. */
-  min-height: var(--mds-icons-lg, 1.5rem);
-  /* Reset Bootstrap's padding-inline-start — it exists to indent label text past a
-     floated input, which our grid layout does not use. column-gap handles the spacing. */
-  padding: var(--mds-spacing-none, 0);
-  /* column-gap keeps input and label spaced; row-gap gives breathing room above feedback */
-  column-gap: var(--mds-spacing-xs, 0.5rem);
-  row-gap: var(--mds-spacing-xxs, 0.25rem);
+  padding: var(--mds-spacing-none);
+  column-gap: var(--mds-spacing-xs);
+  row-gap: var(--mds-spacing-xxs);
 
-  /* UI text/UI default */
-  font-family: var(--mds-font-family-base, Arial, sans-serif);
-  font-size: var(--mds-font-size-body, 1rem);
-  font-weight: var(--mds-font-weight-regular, 400);
-  line-height: var(--mds-line-height-paragraph-xs, 0.75rem);
-  letter-spacing: var(--mds-letter-spacing, 0);
+  font-family: var(--mds-font-family-base);
+  font-size: var(--mds-font-size-paragraph-default);
+  font-weight: var(--mds-font-weight-regular);
+  line-height: var(--mds-line-height-paragraph-default);
+  letter-spacing: var(--mds-letter-spacing-default);
 }
 
-/* Input element styles */
-.mds-form-check-input {
-  border-radius: var(--mds-border-radius-pill, 50rem);
-  border: var(--mds-stroke-weight-sm, 1px) solid
-    var(--mds-border-interactive-secondary-default, #6a737b);
-  /* Use background-color, not the background shorthand — the shorthand resets
-     background-image to none, which wipes out Bootstrap's --bs-form-check-bg-image
-     (the inner dot SVG) on the checked state. */
+/* Touch-target wrapper: enforces the Figma minimum height and vertically centres the
+   indicator within it so it optically aligns with the first line of a wrapped label. */
+.mds-radio[class] .mds-radio-input-wrapper {
+  display: flex;
+  align-items: center;
+  min-height: 24px; /* Intentional Figma fixed size. */
 }
-/* Bootstrap's .form-check .form-check-input rule (specificity 0,2,0) sets float: left
-   and a negative margin-inline-start that causes overlap. Match its specificity to
-   ensure our flex-friendly reset wins regardless of load order. */
-.mds-form-check .mds-form-check-input {
+
+.mds-radio[class] .mds-radio-input {
+  border-radius: var(--mds-border-radius-pill);
+  border: var(--mds-stroke-weight-sm) solid
+    var(--mds-border-interactive-secondary-default);
+  /* Disable Bootstrap's state transitions to avoid a one-frame focus colour flash. */
+  transition: none;
+  /* Avoid the background shorthand so Bootstrap's checked dot SVG remains applied. */
   margin: 0;
   float: none;
-  background-color: var(--mds-bg-surface-default, #fff);
+  background-color: var(--mds-bg-surface-default);
 }
-.mds-form-check-input:checked {
+.mds-radio[class] .mds-radio-input:checked {
   background-color: var(--mds-bg-interactive-primary-default);
   border-color: transparent;
 }
-.mds-form-check-input:disabled {
+.mds-radio[class] .mds-radio-input:disabled {
   border-color: var(--mds-border-interactive-secondary-disabled);
 }
-.mds-form-check-input:disabled:checked {
+.mds-radio[class] .mds-radio-input:disabled:checked {
   background-color: var(--mds-bg-interactive-primary-disabled);
   border-color: transparent;
 }
-.mds-form-check-input.is-invalid {
+.mds-radio[class] .mds-radio-input.is-invalid {
   border-color: var(--mds-border-interactive-danger-default);
 }
-.mds-form-check-input.is-invalid:checked {
+.mds-radio[class] .mds-radio-input.is-invalid:checked {
   background-color: var(--mds-bg-interactive-danger-default);
   border-color: transparent;
 }
-/* Explicit rule for invalid + disabled to avoid relying on specificity cascade order.
-   Disabled takes visual precedence: use the disabled background/border, not the danger ones. */
-.mds-form-check-input.is-invalid:disabled {
+
+/* Disabled takes precedence over invalid when both states are active. */
+.mds-radio[class] .mds-radio-input.is-invalid:disabled {
   background-color: var(--mds-bg-interactive-secondary-disabled);
   border-color: var(--mds-border-interactive-secondary-disabled);
 }
-.mds-form-check-input.is-invalid:disabled:checked {
+.mds-radio[class] .mds-radio-input.is-invalid:disabled:checked {
   background-color: var(--mds-bg-interactive-primary-disabled);
   border-color: transparent;
 }
-/* is-valid (Bootstrap) and neutral feedback states are intentionally not supported.
-   Radio buttons surface a binary valid/invalid result; positive confirmation
-   is conveyed by form-level success messaging rather than per-input valid styling. */
-/* Hover styles are intentionally omitted. The radio input relies on the OS/browser
-   default appearance for hover; no design token exists for a radio hover state. */
-
-/* Focus ring: Only outline + outline-offset allowed (no box-shadow or border).
-  See .github/instructions/components.instructions.md for full rules and rationale. */
-.mds-form-check-input:focus,
-.mds-form-check-input.is-invalid:focus {
+.mds-radio[class] .mds-radio-input:focus {
   /* Reset Bootstrap's :focus box-shadow; our ring is applied on :focus-visible only */
   box-shadow: none;
   outline: none;
 }
-.mds-form-check-input:focus-visible {
+.mds-radio[class] .mds-radio-input:focus-visible {
   outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
   outline-offset: var(--mds-spacing-offset);
   box-shadow: none;
 }
-.mds-form-check-input.is-invalid:focus-visible {
+.mds-radio[class] .mds-radio-input.is-invalid:focus-visible {
   outline: var(--mds-stroke-weight-md) solid var(--mds-border-feedback-danger);
   outline-offset: var(--mds-spacing-offset);
   box-shadow: none;
 }
 
-/* Label element styles */
-.mds-form-check .form-check-label,
-.mds-form-check .mds-form-check-label {
-  color: var(--mds-text-default, #1d2125);
+.mds-radio[class] .mds-radio-label {
+  color: var(--mds-text-default);
 }
-/* Use sibling selector so the label reflects the input's disabled/invalid state */
-.mds-form-check .mds-form-check-input:disabled ~ .form-check-label,
-.mds-form-check .mds-form-check-input:disabled ~ .mds-form-check-label {
+
+/* Use :has() on the wrapper so label colour follows the input state across the wrapper boundary. */
+.mds-radio[class] .mds-radio-input-wrapper:has(:disabled) ~ .mds-radio-label {
   color: var(--mds-text-muted);
 }
-.mds-form-check .mds-form-check-input.is-invalid ~ .form-check-label,
-.mds-form-check .mds-form-check-input.is-invalid ~ .mds-form-check-label {
+.mds-radio[class] .mds-radio-input-wrapper:has(.is-invalid) ~ .mds-radio-label {
   color: var(--mds-text-danger);
 }
 
-/* Feedback element styles — UI text/UI small */
-.mds-form-check .invalid-feedback,
-.mds-form-check .mds-form-check-feedback {
-  /* Place feedback in column 2 (the label column) so it aligns with the label
-     regardless of input size or font-size differences. Row placement is automatic. */
+/* Disabled takes precedence over invalid — restore muted colour when both are active. */
+.mds-radio[class]
+  .mds-radio-input-wrapper:has(.is-invalid:disabled)
+  ~ .mds-radio-label {
+  color: var(--mds-text-muted);
+}
+
+.mds-radio[class] .mds-radio-feedback {
+  /* Bootstrap hides .invalid-feedback via display:none and reveals it with an .is-invalid
+     sibling selector. The input is now inside .mds-radio-input-wrapper so that selector
+     no longer reaches the feedback div. Override here — we control rendering in JSX. */
+  display: block;
+  /* Keep feedback aligned with the label column in the grid layout. */
   grid-column: 2;
-  font-size: var(--mds-font-size-paragraph-small, 0.875rem);
-  font-weight: var(--mds-font-weight-medium, 500);
-  line-height: var(--mds-line-height-paragraph-xs, 0.75rem);
+  font-size: var(--mds-font-size-paragraph-small);
+  font-weight: var(--mds-font-weight-medium);
+  line-height: var(--mds-line-height-paragraph-xs);
   color: var(--mds-text-danger);
 }
-/* Dim the feedback when the input is disabled to match the reduced visual weight of
-   the label and input; keeps the feedback legible without implying it is actionable. */
-.mds-form-check:has(.mds-form-check-input:disabled) .invalid-feedback,
-.mds-form-check:has(.mds-form-check-input:disabled) .mds-form-check-feedback {
+.mds-radio[class]
+  .mds-radio-input-wrapper:has(:disabled)
+  ~ .mds-radio-feedback {
   opacity: 0.5;
 }


### PR DESCRIPTION
## Description

This PR fixes alignment issues and tightens selector specificity in Radio and Checkbox when rendered alongside Bootstrap form styles.

**Radio — class hooks renamed**
- Root wrapper: `mds-form-check` → `mds-radio`
- Input: `mds-form-check-input` → `mds-radio-input`
- Label: `mds-form-check-label` → `mds-radio-label`
- Feedback: `mds-form-check-feedback` → `mds-radio-feedback`
- Unit tests updated to assert the new class names.

**Radio & Checkbox — input-wrapper pattern**
- Wrapped `<input>` in a `*-input-wrapper` div (flex, `min-height: 24px`) so the indicator enforces the Figma touch target and optically aligns with the first line of a multi-line label.
- All CSS sibling selectors that previously targeted `input ~ label/feedback` updated to use `:has()` on the wrapper (`wrapper:has(.is-invalid) ~ label`) since the input is no longer a direct sibling.
- Added `display: block` to both `mds-checkbox-feedback` and `mds-radio-feedback` — Bootstrap hides `.invalid-feedback` by default via `.is-invalid ~ .invalid-feedback`, which no longer reaches the feedback div across the wrapper boundary.
- Added `WrappedLabel` stories to both `Checkbox.stories.tsx` and `Radio.stories.tsx` to verify indicator top-alignment and text wrapping at narrow widths.

**Radio & Checkbox — selector specificity**
- All CSS rules qualified with `[class]` on the root (e.g. `.mds-radio[class]`, `.mds-checkbox[class]`), raising specificity above Bootstrap's single-class selectors without depending on optional classes like `form-check`.

**Radio & Checkbox — disabled takes precedence over invalid**
- `disabled` destructured in both components and added to the `feedbackId` guard — feedback div is not rendered when `disabled` is true.
- CSS restored: `is-invalid:disabled` state shows muted label colour, not danger.
- New unit tests in `Checkbox.test.tsx` cover the `disabled + invalid` combination.

**Checkbox — CSS cleanup**
- Removed duplicated selectors targeting both `.form-check-label` and `.mds-checkbox-label`; now only `mds-checkbox-label` is targeted.
- Consolidated `:checked` and `:indeterminate` state rules using `:is()`.
- Supporting text colour logic clarified: subtle by default, danger only when `is-invalid:not(:disabled)`.

**Storybook UX improvements (both components)**
- `aria-label` control shown only when `hideLabel` is true (`if: { arg: 'hideLabel', truthy: true }`).
- `invalidFeedback` control shown only when `invalid` is true.
- Default stories converted to controlled args via `useArgs` so Storybook controls stay in sync with rendered state.
- `DefaultChecked` story renamed to "Uncontrolled checked" with an explicit code example.
- `className` argType removed from Checkbox docs (not useful to surface in controls).
- Play functions updated to assert stable visible state without leaving focus styling active.

**Instructions update**
- `.github/instructions/components.instructions.md` — minor formatting fix in the focus-ring CSS example.

**Why `[class]` instead of `.mds-radio.form-check`**

In `hideLabel` mode, `form-check` is intentionally not applied to the wrapper, so `.mds-radio.form-check` selectors would silently stop matching. `[class]` is always present and raises specificity without depending on optional Bootstrap classes.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-607

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews
Screenshots from LMS PVT testbed:
<img width="205" height="167" alt="Screenshot 2026-07-21 at 2 31 51 pm" src="https://github.com/user-attachments/assets/0c153825-5327-4e54-be18-ac84302d4331" />
<img width="251" height="74" alt="Screenshot 2026-07-21 at 2 30 54 pm" src="https://github.com/user-attachments/assets/b0e41221-6866-4144-84f9-628cee7c14c4" />

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes
- The parent of the Radio button (in the PVT testbed) should now have been adjusted as per our SB docs cc @Chocolate-lightning 
> The two layouts below use a flex container to demonstrate both common arrangements. Neither is provided by this component — choose whichever suits the surrounding form.
```
  display: flex;
  flex-direction: column;
```