### PR TITLE
chore(CI): Update AI context, CI more performant, Testing infra updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,9 +71,8 @@ These MCP servers are useful when working in this repo. Configure them in your A
 - Unit tests: `npm run test-unit` (Vitest + jsdom, component tests only).
 - Storybook interaction/a11y tests: `npm run test-storybook` (Vitest browser mode + Playwright + Storybook addon plugin).
 - Coverage for unit tests: `npm run test-unit-coverage` (Istanbul thresholds: 50% minimum, 80% target for statement coverage — configured in `vitest.config.ts`).
-- Run a single unit test file: `VITEST_STORYBOOK=false npx vitest run components/button/Button.test.tsx`.
-- The `VITEST_STORYBOOK` env var switches vitest: `false` runs `components/**/*.{test,spec}.*` in jsdom; `true` runs stories tagged `test` via Playwright/Chromium headless.
-- Test configuration lives in `vitest.config.ts`. `vite.config.ts` also defines a Storybook Vitest project (browser + Playwright) as part of the build config — do not edit that block for test configuration changes.
+- Run a single unit test file: `npx vitest run --project unit components/button/Button.test.tsx`.
+- `vitest.config.ts` defines two Vitest projects: `unit` (jsdom, `components/**/*.{test,spec}.*`) and `storybook` (Playwright/Chromium, stories tagged `test`). Filter with `--project unit` or `--project storybook`; omitting the flag runs both. `vite.config.ts` also defines its own Storybook Vitest project (browser + Playwright) as part of the build config, used by the Storybook UI's own test integration — do not edit that block for CLI test configuration changes.
 - Reuse `tests/utils/fuzzComponent.ts` + `fast-check` for property-based fuzz tests where inputs have broad permutations.
 - Story files should include `tags: ['autodocs', 'test', 'stable']` unless intentionally excluding from Storybook Vitest runs.
 
@@ -119,6 +118,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for branch, PR, review, and release proce
 2. If a matching token exists → use it via `var(--mds-*)`.
 3. When using an existing `--mds-*` token, do not add a fallback literal in `var(...)` (for example, avoid `var(--mds-token, 1rem)` and use `var(--mds-token)` instead).
 4. If no token exists → do not invent an ad-hoc value. Ask contributors to request one at https://design.moodle.com/.
+
+**Fonts are not bundled:** `--mds-font-family-base` resolves to `Noto Sans` with no CSS fallback chain. When scaffolding a consuming app (not the library itself), always include the README's "Fonts" instructions (Google Fonts link or self-hosted `@font-face`) — otherwise text silently renders in the browser default font with no warning.
+
+**When multiple `Radio`, `Checkbox`, or `NavPill` instances are rendered together:** none of these components ships a layout wrapper. Lay them out with a consumer-provided container (for example, flex) and a `--mds-spacing-*` gap token — see each component's stories for the reference pattern.
 
 **When working from a Figma design:**
 

--- a/.github/instructions/component-index.instructions.md
+++ b/.github/instructions/component-index.instructions.md
@@ -8,23 +8,23 @@ Quick reference for AI agents and developers.
 
 ## Components
 
-| Component       | Purpose                                                    | Key props                                        |
-| --------------- | ---------------------------------------------------------- | ------------------------------------------------ |
-| ActivityIcon    | Activity/resource/file icon with semantic category styling | icon, category, size, container                  |
-| Avatar          | Circular user/entity identity display — photo or initials  | type, size, initials, imageSrc, imageAlt         |
-| Badge           | Short status, metadata, or count labels                    | type, contrast, style, icon, label               |
-| Button          | Primary and secondary actions                              | variant, size, disabled, startIcon, endIcon      |
-| Checkbox        | Independent multi-select controls                          | checked, label, disabled, invalid, indeterminate |
-| Choicebox       | Single-select options in a group                           | checked, label, disabled, invalid                |
-| CloseButton     | Icon-only dismiss action for temporary UI surfaces         | size, disabled, ariaLabel                        |
-| FavouriteButton | Icon button to mark/unmark items as favourites             | checked, size, disabled, ariaLabel               |
-| Link            | Anchor element with variant and optional icon support      | label, variant, disabled, startIcon, endIcon     |
-| NavPill         | Compact pill-style navigation link for section switching   | label, active, disabled, href, ariaLabel         |
-| Pagination      | Page navigation control                                    | totalPages, currentPage, onPageChange, ariaLabel |
-| ProgressBar     | Visual progress indicator with status and label variants   | value, min, max, status, labelVariant, title     |
-| Radio           | Single-select options in a group                           | checked, label, disabled, invalid                |
-| Switch          | Binary toggle control for on/off settings                  | checked, label, disabled, onChange               |
-| Tooltip         | Contextual label anchored to a trigger element             | label, placement, variant, children              |
+| Component       | Purpose                                                                              | Key props                                        |
+| --------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| ActivityIcon    | Activity/resource/file icon with semantic category styling                           | icon, category, size, container                  |
+| Avatar          | Circular user/entity identity display — photo or initials                            | type, size, initials, imageSrc, imageAlt         |
+| Badge           | Short status, metadata, or count labels                                              | type, contrast, style, icon, label               |
+| Button          | Primary and secondary actions                                                        | variant, size, disabled, startIcon, endIcon      |
+| Checkbox        | Independent multi-select controls                                                    | checked, label, disabled, invalid, indeterminate |
+| Choicebox       | Single-select options as larger, card-style choices (icon + label + supporting text) | checked, label, disabled, invalid                |
+| CloseButton     | Icon-only dismiss action for temporary UI surfaces                                   | size, disabled, ariaLabel                        |
+| FavouriteButton | Icon button to mark/unmark items as favourites                                       | checked, size, disabled, ariaLabel               |
+| Link            | Anchor element with variant and optional icon support                                | label, variant, disabled, startIcon, endIcon     |
+| NavPill         | Compact pill-style navigation link for section switching                             | label, active, disabled, href, ariaLabel         |
+| Pagination      | Page navigation control                                                              | totalPages, currentPage, onPageChange, ariaLabel |
+| ProgressBar     | Visual progress indicator with status and label variants                             | value, min, max, status, labelVariant, title     |
+| Radio           | Single-select options in a compact list (native radio input, label only)             | checked, label, disabled, invalid                |
+| Switch          | Binary toggle control for on/off settings                                            | checked, label, disabled, onChange               |
+| Tooltip         | Contextual label anchored to a trigger element                                       | label, placement, variant, children              |
 
 ## Component Links
 
@@ -65,6 +65,9 @@ Quick reference for AI agents and developers.
 - Use published MDS tokens through CSS variables only; avoid hardcoded design values.
 - Treat generated token outputs as read-only and update only source token flows.
 - Keep Storybook variants and tests aligned with component API changes.
+- `Radio`, `Checkbox`, and `NavPill` do not ship a group/layout wrapper — when multiple instances are rendered together, layout is supplied by the consumer (for example, a flex container + gap). See each component's stories for the reference pattern; do not invent a new wrapper component.
+- `Radio` and `Choicebox` both render single-select options but are not interchangeable: use `Radio` for a plain list of text options, `Choicebox` for larger card-style options with an icon and/or supporting text.
+- This package does not bundle font files. `--mds-font-family-base` resolves to `Noto Sans` with no fallback chain — the consuming application must load Noto Sans itself (see the README "Fonts" section) or text will fall back to the browser default with no build-time warning.
 
 ## Documentation Routing
 

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -113,6 +113,10 @@ import { Card, CardHeader, CardBody } from '@moodlehq/design-system';
 
 Each sub-component follows the same file structure rules as any other component and must have its own stories and tests.
 
+## Group / multi-instance composition (Radio, Checkbox, NavPill)
+
+`Radio`, `Checkbox`, and `NavPill` are single-instance components — none ships a group wrapper, layout, or spacing. When multiple instances are rendered together (for example, a radio group sharing a `name`, a related checkbox set, or a row of navigation pills), the consumer supplies the container and its layout direction (for example, a flex container with a `--mds-spacing-*` gap token). Do not add a new wrapper component or hardcode spacing inside `Radio`/`Checkbox`/`NavPill` to solve this — follow each component's stories for the reference pattern.
+
 ## Breaking change guardrail
 
 The following changes to a component's public API are breaking and must not be made without a major version bump:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,6 +2,9 @@ name: CI
 on: pull_request
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   commitlint:
     runs-on: ubuntu-latest
@@ -14,9 +17,10 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.22.2
+          cache: 'npm'
 
-      - name: Install commitlint
-        run: npm install -D @commitlint/cli @commitlint/config-conventional
+      - name: Install dependencies
+        run: npm ci
 
       - name: Print versions
         run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,9 +18,14 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.22.2
+          registry-url: 'https://registry.npmjs.org' # required for npm to attempt OIDC trusted publishing
 
       - name: Install dependencies
         run: npm ci
+
+      # Trusted publishing (OIDC) requires npm CLI >= 11.5.1; the version bundled with Node 22.22.2 is older.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Audit dependencies
         run: npm audit --audit-level=high

--- a/.github/workflows/release-tooling.yml
+++ b/.github/workflows/release-tooling.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  NODE_VERSION: 22.22.1
+  NODE_VERSION: 22.22.2
 
 permissions:
   contents: read # Restrict top-level permissions to read only

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   storybook-accessibility:
     runs-on: ubuntu-latest
@@ -23,11 +27,10 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
-      - name: Clean install
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+      - name: Install dependencies
+        run: npm ci
 
       - name: Install Playwright runtime
         run: npx playwright install --with-deps chromium
@@ -44,16 +47,13 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
-      - name: Clean install
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         run: npm run test-unit-coverage
-        env:
-          SB_URL: '${{ github.event.deployment_status.environment_url }}'
 
   lint-format-build:
     runs-on: ubuntu-latest
@@ -64,11 +64,10 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
-      - name: Clean install
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+      - name: Install dependencies
+        run: npm ci
 
       - name: Lint
         run: npx eslint . --ext .ts,.tsx,.js,.jsx --config .github/linters/eslint.config.mjs
@@ -92,11 +91,10 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
-      - name: Clean install
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run Chromatic
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0

--- a/components/badge/Badge.test.tsx
+++ b/components/badge/Badge.test.tsx
@@ -157,7 +157,6 @@ describe('Badge: Unit Test', () => {
       <i className="fa fa-star" data-testid="end-icon" aria-hidden="true" />
     );
 
-    // @ts-expect-error — intentional invalid icon to verify resolved-only conflict warning
     render(<Badge label="Label" startIcon={<div />} endIcon={end} />);
 
     expect(warn).not.toHaveBeenCalledWith(
@@ -171,7 +170,6 @@ describe('Badge: Unit Test', () => {
 
   it('ignores an invalid startIcon value and logs an error', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // @ts-expect-error — intentional invalid icon
     render(<Badge label="Label" startIcon={<div />} />);
     expect(error).toHaveBeenCalledWith(expect.stringContaining('startIcon'));
     vi.restoreAllMocks();
@@ -179,7 +177,6 @@ describe('Badge: Unit Test', () => {
 
   it('ignores an invalid endIcon value and logs an error', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // @ts-expect-error — intentional invalid icon
     render(<Badge label="Label" endIcon={<div />} />);
     expect(error).toHaveBeenCalledWith(expect.stringContaining('endIcon'));
     expect(screen.queryByTestId('end-icon')).not.toBeInTheDocument();

--- a/components/button/Button.test.tsx
+++ b/components/button/Button.test.tsx
@@ -45,6 +45,7 @@ describe('Button: Unit Test', () => {
 
     it('falls back to primary and warns in development for an invalid variant', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // @ts-expect-error deliberately invalid value to verify runtime fallback
       render(<Button label="Button" variant="invalid" />);
       expect(screen.getByRole('button')).toHaveClass('btn-primary');
       expect(warnSpy).toHaveBeenCalledWith(
@@ -73,6 +74,7 @@ describe('Button: Unit Test', () => {
 
     it('falls back to md and warns in development for an invalid size', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // @ts-expect-error deliberately invalid value to verify runtime fallback
       render(<Button label="Button" size="invalid" />);
       expect(screen.getByRole('button')).toHaveClass('mds-btn--size-md');
       expect(warnSpy).toHaveBeenCalledWith(
@@ -263,7 +265,7 @@ describe('Button: Unit Test', () => {
 
   describe('accessibility', () => {
     it('warns in dev when no label, aria-label, or aria-labelledby', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       render(<Button />);
       expect(warnSpy).toHaveBeenCalledWith(
         'Button: provide a label, aria-label, or aria-labelledby for accessibility.',
@@ -272,7 +274,7 @@ describe('Button: Unit Test', () => {
     });
 
     it('warns in dev when no label and no icons (visually empty)', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       render(<Button />);
       expect(warnSpy).toHaveBeenCalledWith(
         'Button: provide a label or icon so the button does not render as visually empty.',
@@ -281,7 +283,7 @@ describe('Button: Unit Test', () => {
     });
 
     it('does not warn about visual emptiness when label is provided', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       render(<Button label="Button" />);
       expect(warnSpy).not.toHaveBeenCalledWith(
         'Button: provide a label or icon so the button does not render as visually empty.',
@@ -290,7 +292,7 @@ describe('Button: Unit Test', () => {
     });
 
     it('does not warn about visual emptiness when icon is provided', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       render(
         <Button startIcon={<i aria-hidden="true" />} aria-label="Action" />,
       );
@@ -301,7 +303,7 @@ describe('Button: Unit Test', () => {
     });
 
     it('does not warn when only aria-label is provided', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       render(<Button aria-label="Close" />);
       expect(warnSpy).not.toHaveBeenCalledWith(
         'Button: provide a label, aria-label, or aria-labelledby for accessibility.',
@@ -310,7 +312,7 @@ describe('Button: Unit Test', () => {
     });
 
     it('does not warn when only aria-labelledby is provided', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       render(<Button aria-labelledby="some-id" />);
       expect(warnSpy).not.toHaveBeenCalledWith(
         'Button: provide a label, aria-label, or aria-labelledby for accessibility.',
@@ -319,7 +321,7 @@ describe('Button: Unit Test', () => {
     });
 
     it('warns when aria-label is an empty string', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       render(<Button aria-label="" />);
       expect(warnSpy).toHaveBeenCalledWith(
         'Button: provide a label, aria-label, or aria-labelledby for accessibility.',
@@ -328,7 +330,7 @@ describe('Button: Unit Test', () => {
     });
 
     it('warns when aria-labelledby is an empty string', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       render(<Button aria-labelledby="" />);
       expect(warnSpy).toHaveBeenCalledWith(
         'Button: provide a label, aria-label, or aria-labelledby for accessibility.',
@@ -370,7 +372,7 @@ describe('Button: Unit Test', () => {
           }) as unknown as fc.Arbitrary<ButtonProps['size']>,
         }),
         // For each generated prop set, assert that the generated label text is present.
-        (props: ButtonProps) => props.label,
+        (props: ButtonProps) => props.label ?? '',
         // Run 100 generated cases for a good speed/coverage balance.
         { numRuns: 100 },
       );

--- a/components/checkbox/Checkbox.test.tsx
+++ b/components/checkbox/Checkbox.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import fc from 'fast-check';
 import { type JSX } from 'react';

--- a/components/choicebox/Choicebox.test.tsx
+++ b/components/choicebox/Choicebox.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fc from 'fast-check';
@@ -131,7 +130,6 @@ describe('Choicebox: Unit Tests', () => {
   it('silently ignores an invalid icon element and does not render the icon slot', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(
-      // @ts-expect-error — intentional invalid type for test
       <Choicebox label="Option A" icon={<span>not-an-icon</span>} />,
     );
     expect(
@@ -262,19 +260,17 @@ describe('Choicebox: Unit Tests', () => {
   it('renders without throwing for arbitrary label/supportingText strings', () => {
     fuzzComponent(
       Choicebox,
-      fc.record<ChoiceboxProps>({
+      fc.record({
         label: fc
           .array(fc.constantFrom(...fuzzLabelCharacters.split('')), {
             minLength: 1,
             maxLength: 50,
           })
-          .map((chars) => chars.join('')) as unknown as fc.Arbitrary<
-          ChoiceboxProps['label']
-        >,
+          .map((chars) => chars.join('')),
         supportingText: fc.oneof(fc.constant(undefined), fc.string()),
         disabled: fc.boolean(),
         checked: fc.boolean(),
-      } as unknown as Record<keyof ChoiceboxProps, fc.Arbitrary<unknown>>),
+      }) as unknown as fc.Arbitrary<ChoiceboxProps>,
       (props) => props.label,
     );
   });

--- a/components/pagination/Pagination.test.tsx
+++ b/components/pagination/Pagination.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ComponentPropsWithoutRef } from 'react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { PaginationProps } from './Pagination';
@@ -11,7 +12,12 @@ const defaultProps: PaginationProps = {
   onPageChange: () => {},
 };
 
-function renderPagination(overrides: Partial<PaginationProps> = {}) {
+type PaginationRenderOverrides = Partial<PaginationProps> &
+  ComponentPropsWithoutRef<'nav'> & {
+    [key: `data-${string}`]: string;
+  };
+
+function renderPagination(overrides: PaginationRenderOverrides = {}) {
   return render(<Pagination {...defaultProps} {...overrides} />);
 }
 
@@ -377,9 +383,14 @@ describe('Pagination: Unit Tests', () => {
   );
 
   it('does not submit a surrounding form when a pagination button is clicked', async () => {
-    const handleSubmit = vi.fn((e: SubmitEvent) => e.preventDefault());
+    const handleSubmit = vi.fn();
     render(
-      <form onSubmit={handleSubmit}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit(e);
+        }}
+      >
         <Pagination {...defaultProps} currentPage={2} />
       </form>,
     );

--- a/components/radio/Radio.test.tsx
+++ b/components/radio/Radio.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import fc from 'fast-check';
 import { describe, expect, it, vi } from 'vitest';

--- a/components/switch/Switch.test.tsx
+++ b/components/switch/Switch.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fc from 'fast-check';

--- a/components/tooltip/Tooltip.test.tsx
+++ b/components/tooltip/Tooltip.test.tsx
@@ -1,5 +1,7 @@
+import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
 import { describe, expect, it } from 'vitest';
 import { Button } from '../button';
 import { Tooltip } from './Tooltip';
@@ -239,10 +241,7 @@ describe('Tooltip: Unit Test', () => {
       expect(() =>
         render(
           <Tooltip label="Info">
-            {
-              // @ts-expect-error deliberately invalid runtime value
-              'Trigger text'
-            }
+            {'Trigger text' as unknown as ReactElement}
           </Tooltip>,
         ),
       ).not.toThrow();

--- a/package.json
+++ b/package.json
@@ -118,11 +118,11 @@
     "vitest": "^4.0.4"
   },
   "scripts": {
-    "test-unit": "VITEST_STORYBOOK=false vitest run",
-    "test-unit-coverage": "VITEST_STORYBOOK=false vitest run --coverage",
-    "test-storybook": "VITEST_STORYBOOK=true vitest run",
+    "test-unit": "vitest run --project unit",
+    "test-unit-coverage": "vitest run --project unit --coverage",
+    "test-storybook": "vitest run --project storybook",
     "storybook": "storybook dev -p 6006",
-    "build": "npm run build-component-index && npm run build-tokens && tsc && vite build",
+    "build": "npm run build-tokens && tsc && vite build && npm run build-component-index",
     "build-component-index": "tsx scripts/generate-component-index.ts",
     "build-storybook": "storybook build",
     "build-docs": "tsx scripts/build-docs.ts",

--- a/scripts/generate-component-index.ts
+++ b/scripts/generate-component-index.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 interface ComponentIndexItem {
   name: string;
   slug: string;
+  purpose: string;
   exportPath: string;
   implementationPath: string;
   storyPath?: string;
@@ -27,6 +28,32 @@ const OUTPUT_DIR = path.join(ROOT_DIR, 'dist');
 const OUTPUT_FILE = path.join(OUTPUT_DIR, 'component-index.json');
 
 const RESERVED_DIR_NAMES = new Set(['assets']);
+
+// One-line "when to use" guidance per component, kept in sync with
+// .github/instructions/component-index.instructions.md. Ships in the published
+// package so agents that only install @moodlehq/design-system (without the source
+// repo's instruction files) still get decision guidance, not just file paths.
+const PURPOSES: Record<string, string> = {
+  'activity-icon':
+    'Activity/resource/file icon with semantic category styling.',
+  avatar: 'Circular user/entity identity display — photo or initials.',
+  badge: 'Short status, metadata, or count labels.',
+  button: 'Primary and secondary actions.',
+  checkbox:
+    'Independent multi-select controls. No group wrapper is provided — see the Group story for consumer-supplied layout.',
+  choicebox:
+    'Single-select options as larger, card-style choices (icon + label + supporting text). Not interchangeable with Radio — use for options that benefit from extra visual weight or a supporting description.',
+  'close-button': 'Icon-only dismiss action for temporary UI surfaces.',
+  'favourite-button': 'Icon button to mark/unmark items as favourites.',
+  link: 'Anchor element with variant and optional icon support.',
+  'nav-pill': 'Compact pill-style navigation link for section switching.',
+  pagination: 'Page navigation control.',
+  'progress-bar': 'Visual progress indicator with status and label variants.',
+  radio:
+    'Single-select options in a compact list (native radio input, label only). No group wrapper is provided — see the Group story for consumer-supplied layout.',
+  switch: 'Binary toggle control for on/off settings.',
+  tooltip: 'Contextual label anchored to a trigger element.',
+};
 
 function toPosix(filePath: string): string {
   return filePath.split(path.sep).join('/');
@@ -70,9 +97,17 @@ function collectComponent(slug: string): ComponentIndexItem | null {
 
   const rel = (fullPath: string) => toPosix(path.relative(ROOT_DIR, fullPath));
 
+  const purpose = PURPOSES[slug];
+  if (!purpose) {
+    throw new Error(
+      `No purpose text defined for component "${slug}" in PURPOSES — add one in scripts/generate-component-index.ts.`,
+    );
+  }
+
   return {
     name: componentName,
     slug,
+    purpose,
     exportPath: `@moodlehq/design-system/components/${slug}`,
     implementationPath: rel(implementation),
     storyPath: story ? rel(story) : undefined,

--- a/tests/utils/fuzzComponent.ts
+++ b/tests/utils/fuzzComponent.ts
@@ -27,11 +27,13 @@ export function fuzzComponent<T>(
 ) {
   fc.assert(
     fc.property(arb, (props) => {
-      // Render the component with random props
-      render(React.createElement(Component, props));
-      // Assert that the key text is present in the rendered output
+      // Unmount after each run — otherwise renders accumulate in the DOM across
+      // all numRuns iterations, making later getAllByText queries progressively
+      // slower and prone to timing out on slower machines.
+      const { unmount } = render(React.createElement(Component, props));
       const matches = screen.getAllByText(getText(props));
       expect(matches.length).toBeGreaterThan(0);
+      unmount();
     }),
     options,
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedParameters": true, // Flags unused function parameters.
     "noFallthroughCasesInSwitch": true, // Requires handling all cases in a switch statement.
     "declaration": true, // Generates declaration files for TypeScript.
-    "types": ["vite/client"] // Provides ImportMeta.env typings from Vite.
+    "types": ["vite/client"] // Provides ImportMeta.env typings from Vite; test matcher types come from vitest.shims.d.ts.
   },
   "include": ["components", "index.ts"], // Specifies the directory to include when searching for TypeScript files.
   "exclude": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,12 +8,8 @@ import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import type { PluginContext } from 'rollup';
-const dirname =
-  typeof __dirname !== 'undefined'
-    ? __dirname
-    : path.dirname(fileURLToPath(import.meta.url));
+const dirname = import.meta.dirname;
 
 // Automatically discover one entry per component directory so new components
 // are included in the build without any manual configuration changes.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,52 +1,18 @@
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
-const dirname =
-  typeof __dirname !== 'undefined'
-    ? __dirname
-    : path.dirname(fileURLToPath(import.meta.url));
-
-const isStorybook = process.env.VITEST_STORYBOOK === 'true';
+const dirname = import.meta.dirname;
 
 export default defineConfig({
   optimizeDeps: {
     include: ['react', 'react-dom', 'react/jsx-dev-runtime'],
   },
-  plugins: isStorybook
-    ? [
-        storybookTest({
-          configDir: path.resolve(dirname, '.storybook'),
-          tags: {
-            include: ['test'],
-            exclude: ['experimental'],
-          },
-        }),
-      ]
-    : [],
   test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: isStorybook ? [] : ['./tests/setupTests.ts'],
-    include: !isStorybook
-      ? ['components/**/*.{test,spec}.{js,ts,jsx,tsx}']
-      : undefined,
-    exclude: isStorybook
-      ? ['components/**/*.{test,spec}.{js,ts,jsx,tsx}']
-      : ['**/*.stories.*', '.storybook/**', '**/.storybook/**'],
-    browser: isStorybook
-      ? {
-          enabled: true,
-          headless: true,
-          provider: playwright({}),
-          instances: [{ browser: 'chromium' }],
-        }
-      : undefined,
     coverage: {
       provider: 'istanbul',
-      include: !isStorybook ? ['components/**/*.{ts,tsx,js,jsx}'] : undefined,
+      include: ['components/**/*.{ts,tsx,js,jsx}'],
       exclude: [
         '**/*.stories.*',
         '**/*.figma.*',
@@ -54,11 +20,51 @@ export default defineConfig({
         '**/.storybook/**',
         'components/**/*.{test,spec}.{js,ts,jsx,tsx}',
       ],
-      watermarks: !isStorybook
-        ? {
-            statements: [50, 80],
-          }
-        : undefined,
+      watermarks: {
+        statements: [50, 80],
+      },
+      // Watermarks above only color the report; thresholds are what actually
+      // fail the run, enforcing the documented 50% statement coverage minimum.
+      thresholds: {
+        statements: 50,
+      },
     },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          globals: true,
+          environment: 'jsdom',
+          setupFiles: ['./tests/setupTests.ts'],
+          include: ['components/**/*.{test,spec}.{js,ts,jsx,tsx}'],
+        },
+      },
+      {
+        extends: true,
+        plugins: [
+          storybookTest({
+            configDir: path.resolve(dirname, '.storybook'),
+            tags: {
+              include: ['test'],
+              exclude: ['experimental'],
+            },
+          }),
+        ],
+        test: {
+          name: 'storybook',
+          globals: true,
+          environment: 'jsdom',
+          setupFiles: [],
+          exclude: ['components/**/*.{test,spec}.{js,ts,jsx,tsx}'],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright({}),
+            instances: [{ browser: 'chromium' }],
+          },
+        },
+      },
+    ],
   },
 });

--- a/vitest.shims.d.ts
+++ b/vitest.shims.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="@vitest/browser-playwright" />
+/// <reference types="@testing-library/jest-dom" />


### PR DESCRIPTION
## Description

This PR is a tooling and CI maintenance pass covering the test runner, build pipeline, and workflow configuration, plus a couple of small documentation/story additions picked up along the way.

**CI workflows**

- Added `concurrency` groups (cancel-in-progress) to `testing.yml` and `commitlint.yml` so superseded pushes on the same ref don't run redundant jobs.
- Replaced the "clean install" step (`rm -rf node_modules package-lock.json && npm install`) with `npm ci` plus `actions/setup-node`'s built-in `cache: 'npm'` across all jobs in `testing.yml` and `commitlint.yml`, for faster and more reproducible installs.
- Removed an unused `SB_URL` env var from the unit-test job in `testing.yml`.
- `publish-package.yml`: added `registry-url` to the Node setup step and an explicit `npm install -g npm@latest` step, since npm's OIDC trusted publishing requires npm CLI ≥ 11.5.1, newer than what ships with Node 22.22.2.
- Bumped `NODE_VERSION` in `release-tooling.yml` from `22.22.1` to `22.22.2` to match the other workflows.

**Test runner (Vitest)**

- Replaced the `VITEST_STORYBOOK` environment-variable branching in `vitest.config.ts` with proper Vitest [projects](https://vitest.dev/guide/projects.html): a `unit` project (jsdom, `components/**/*.{test,spec}.*`) and a `storybook` project (Playwright/Chromium, stories tagged `test`).
- Updated `package.json` scripts (`test-unit`, `test-unit-coverage`, `test-storybook`) to select projects via `--project` instead of the env var.
- Added explicit coverage `thresholds` (50% statements) alongside the existing watermarks, so the documented minimum is actually enforced and fails the run rather than just coloring the report.
- `tests/utils/fuzzComponent.ts` now unmounts the component after each fuzz iteration — previously renders accumulated in the DOM across all `numRuns`, making later queries slower and prone to timing out on slower machines.

**Build pipeline**

- Reordered `npm run build` so `build-component-index` runs after `tsc && vite build` instead of before `build-tokens`, since the index generator now needs the build output.
- `vite.config.ts` / `vitest.config.ts`: replaced the manual `fileURLToPath`/`__dirname` fallback with `import.meta.dirname`.
- `scripts/generate-component-index.ts`: added a required `purpose` field (one-line "when to use" guidance) per component, sourced from a `PURPOSES` map; throws a build-time error if a component is missing an entry. This ships in the published `dist/component-index.json` so agents that only install the package (without the source repo's instruction files) still get decision guidance, not just file paths.

**Documentation**

- `.github/instructions/component-index.instructions.md` and `.github/copilot-instructions.md`: added a purpose/description column, plus guidance notes on `Radio`/`Checkbox` group composition, `Radio` vs `Choicebox`, and the unbundled-fonts caveat.
- `.github/instructions/components.instructions.md`: added a "Group / multi-instance composition" section documenting that `Radio` and `Checkbox` don't ship a group wrapper and consumers must supply the container/layout.
- Added a `Group` story to `Checkbox.stories.tsx` demonstrating horizontal/vertical layouts for multiple checkboxes sharing a `name`, with an interaction test confirming independent (non-exclusive) selection.

## Related Jira or GitHub Issue

<!-- Link to related issues or tickets (e.g., https://moodle.atlassian.net/browse/MDS-191) -->

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [x] Other (please describe): CI/tooling maintenance (workflow config, Vitest project split, build pipeline ordering)

## Screenshots/Previews

No visual component changes other than the new `Checkbox` `Group` story — see Storybook for `Checkbox > Group`.

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](../SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

- No component public API, props, or tokens were changed — this is CI/build tooling plus documentation/story additions.
- The `vitest.config.ts` restructuring is a mechanical migration to Vitest's projects API; behavior of `test-unit`, `test-unit-coverage`, and `test-storybook` should be unchanged aside from the new enforced coverage threshold.
