### PR TITLE
feat(Link): Add new Inline variant

### DIFF
--- a/components/link/Link.figma.tsx
+++ b/components/link/Link.figma.tsx
@@ -7,73 +7,85 @@ const url =
 const variant = figma.enum('Variant', {
   Primary: 'primary',
   Secondary: 'secondary',
+  Inline: 'inline',
 });
 
 const linkLabel = 'Label';
 const linkHref = '#';
 
-figma.connect(Link, url, {
-  variant: { State: 'default', Link: 'none' },
-  props: { variant: variant },
-  example: ({ variant }) => (
-    <Link label={linkLabel} href={linkHref} variant={variant} />
-  ),
-});
+const states = ['default', 'hover', 'pressed', 'focus', 'disabled'] as const;
+const standardVariants = ['Primary', 'Secondary'] as const;
 
-figma.connect(Link, url, {
-  variant: { State: 'hover', Link: 'none' },
-  props: { variant: variant },
-  example: ({ variant }) => (
-    <Link label={linkLabel} href={linkHref} variant={variant} />
-  ),
-});
+for (const selectedVariant of standardVariants) {
+  for (const state of states) {
+    figma.connect(Link, url, {
+      variant: { Variant: selectedVariant, State: state, Link: 'none' },
+      props: { variant: variant },
+      example: ({ variant }) => (
+        <Link
+          label={linkLabel}
+          href={linkHref}
+          variant={variant}
+          disabled={state === 'disabled'}
+        />
+      ),
+    });
+  }
+}
 
-figma.connect(Link, url, {
-  variant: { State: 'pressed', Link: 'none' },
-  props: { variant: variant },
-  example: ({ variant }) => (
-    <Link label={linkLabel} href={linkHref} variant={variant} />
-  ),
-});
+for (const selectedVariant of standardVariants) {
+  figma.connect(Link, url, {
+    variant: { Variant: selectedVariant, State: 'default', Link: 'startIcon' },
+    props: { variant: variant },
+    example: ({ variant }) => (
+      <Link
+        label={linkLabel}
+        href={linkHref}
+        variant={variant}
+        startIcon={<i className="fa-solid fa-arrow-left" />}
+      />
+    ),
+  });
 
-figma.connect(Link, url, {
-  variant: { State: 'focus', Link: 'none' },
-  props: { variant: variant },
-  example: ({ variant }) => (
-    <Link label={linkLabel} href={linkHref} variant={variant} />
-  ),
-});
+  figma.connect(Link, url, {
+    variant: { Variant: selectedVariant, State: 'default', Link: 'endIcon' },
+    props: { variant: variant },
+    example: ({ variant }) => (
+      <Link
+        label={linkLabel}
+        href={linkHref}
+        variant={variant}
+        endIcon={<i className="fa-solid fa-arrow-right" />}
+      />
+    ),
+  });
+}
 
-figma.connect(Link, url, {
-  variant: { State: 'disabled', Link: 'none' },
-  props: { variant: variant },
-  example: ({ variant }) => (
-    <Link label={linkLabel} href={linkHref} variant={variant} disabled />
-  ),
-});
+for (const state of states) {
+  figma.connect(Link, url, {
+    variant: { Variant: 'Inline', State: state, Link: 'none' },
+    props: { variant: variant },
+    example: ({ variant }) => (
+      <Link
+        label={linkLabel}
+        href={linkHref}
+        variant={variant}
+        disabled={state === 'disabled'}
+      />
+    ),
+  });
 
-figma.connect(Link, url, {
-  variant: { State: 'default', Link: 'startIcon' },
-  props: { variant: variant },
-  example: ({ variant }) => (
-    <Link
-      label={linkLabel}
-      href={linkHref}
-      variant={variant}
-      startIcon={<i className="fa-solid fa-arrow-left" />}
-    />
-  ),
-});
-
-figma.connect(Link, url, {
-  variant: { State: 'default', Link: 'endIcon' },
-  props: { variant: variant },
-  example: ({ variant }) => (
-    <Link
-      label={linkLabel}
-      href={linkHref}
-      variant={variant}
-      endIcon={<i className="fa-solid fa-arrow-right" />}
-    />
-  ),
-});
+  figma.connect(Link, url, {
+    variant: { Variant: 'Inline', State: state, Link: 'endIcon' },
+    props: { variant: variant },
+    example: ({ variant }) => (
+      <Link
+        label={linkLabel}
+        href={linkHref}
+        variant={variant}
+        disabled={state === 'disabled'}
+        endIcon={<i className="fa-solid fa-arrow-up-right-from-square" />}
+      />
+    ),
+  });
+}

--- a/components/link/Link.stories.tsx
+++ b/components/link/Link.stories.tsx
@@ -3,9 +3,11 @@ import { expect, fireEvent, fn } from 'storybook/test';
 import { Link } from './Link';
 
 const iconMapping = {
-  None: undefined,
   'Arrow Left': <i className="fa-solid fa-arrow-left" aria-hidden="true" />,
   'Arrow Right': <i className="fa-solid fa-arrow-right" aria-hidden="true" />,
+  'External Link': (
+    <i className="fa-solid fa-arrow-up-right-from-square" aria-hidden="true" />
+  ),
 };
 
 const meta = {
@@ -28,19 +30,20 @@ const meta = {
     },
     variant: {
       control: { type: 'select' },
-      options: ['primary', 'secondary'],
+      options: ['primary', 'secondary', 'inline'],
       description: 'Link visual variant.',
       table: {
-        type: { summary: 'primary | secondary' },
+        type: { summary: 'primary | secondary | inline' },
         defaultValue: { summary: 'primary' },
       },
     },
     startIcon: {
       description:
-        'Icon rendered before the label. Accepts only intrinsic `<i>` or `<svg>` elements.',
+        'Icon rendered before the label. Accepts only intrinsic `<i>` or `<svg>` elements. Not supported for the `inline` variant.',
       options: Object.keys(iconMapping),
       mapping: iconMapping,
       control: { type: 'select' },
+      if: { arg: 'variant', neq: 'inline' },
     },
     endIcon: {
       description:
@@ -119,7 +122,28 @@ export const Variants: Story = {
     <div style={{ display: 'flex', gap: 'var(--mds-spacing-xl)' }}>
       <Link label="Primary" href="#storybook-link" />
       <Link label="Secondary" href="#storybook-link" variant="secondary" />
+      <Link label="Inline" href="#storybook-link" variant="inline" />
     </div>
+  ),
+};
+
+export const InlineInParagraph: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: { canvas: { sourceState: 'none' } },
+  },
+  render: () => (
+    <p
+      style={{
+        fontSize: 'var(--mds-font-size-paragraph-default)',
+        lineHeight: 'var(--mds-line-height-paragraph-default)',
+        margin: 0,
+      }}
+    >
+      Review the assessment guide in the{' '}
+      <Link label="course handbook" href="#storybook-link" variant="inline" />{' '}
+      before submitting your assignment.
+    </p>
   ),
 };
 
@@ -200,14 +224,16 @@ const matrixStateCellStyle = {
   display: 'inline-flex' as const,
   alignItems: 'center' as const,
   justifyContent: 'flex-start' as const,
+  lineHeight: 'var(--mds-line-height-paragraph-xs)',
 };
 
 const linkMatrixVariants = [
   { label: 'Primary', variant: 'primary' as const },
   { label: 'Secondary', variant: 'secondary' as const },
+  { label: 'Inline', variant: 'inline' as const },
 ];
 
-const linkMatrixUsages = [
+const defaultLinkMatrixUsages = [
   { label: 'No icon', startIcon: undefined, endIcon: undefined },
   {
     label: 'Start icon',
@@ -218,6 +244,15 @@ const linkMatrixUsages = [
     label: 'End icon',
     startIcon: undefined,
     endIcon: iconMapping['Arrow Right'],
+  },
+];
+
+const inlineLinkMatrixUsages = [
+  { label: 'No icon', startIcon: undefined, endIcon: undefined },
+  {
+    label: 'End icon',
+    startIcon: undefined,
+    endIcon: iconMapping['External Link'],
   },
 ];
 
@@ -260,8 +295,13 @@ export const StateMatrix: Story = {
       </div>
 
       {/* Data rows: variant × icon usage */}
-      {linkMatrixVariants.flatMap((variantDef) =>
-        linkMatrixUsages.map((usage) => (
+      {linkMatrixVariants.flatMap((variantDef) => {
+        const usages =
+          variantDef.variant === 'inline'
+            ? inlineLinkMatrixUsages
+            : defaultLinkMatrixUsages;
+
+        return usages.map((usage) => (
           <div
             key={`${variantDef.variant}-${usage.label}`}
             style={matrixGridStyle}
@@ -288,8 +328,8 @@ export const StateMatrix: Story = {
               );
             })}
           </div>
-        )),
-      )}
+        ));
+      })}
     </div>
   ),
 };

--- a/components/link/Link.test.tsx
+++ b/components/link/Link.test.tsx
@@ -19,6 +19,11 @@ describe('Link: Unit Test', () => {
       expect(screen.getByRole('link')).toHaveClass('mds-link--secondary');
     });
 
+    it('renders the inline variant class', () => {
+      render(<Link label="Inline link" href="#docs" variant="inline" />);
+      expect(screen.getByRole('link')).toHaveClass('mds-link--inline');
+    });
+
     it('falls back to primary and warns in development for an invalid variant', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -58,7 +63,7 @@ describe('Link: Unit Test', () => {
       expect(screen.getByTestId('end-icon')).toBeInTheDocument();
     });
 
-    it('renders only the start icon and warns when both icons are passed', () => {
+    it('renders only the start icon and warns when both icons are passed for non-inline variants', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       render(
@@ -75,6 +80,51 @@ describe('Link: Unit Test', () => {
       expect(screen.getByTestId('start-icon')).toBeInTheDocument();
       expect(screen.queryByTestId('end-icon')).not.toBeInTheDocument();
       expect(warnSpy).toHaveBeenCalledWith(
+        'Link: pass either startIcon or endIcon, not both. Rendering startIcon only.',
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('ignores startIcon for inline variant and warns', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      render(
+        <Link
+          label="Inline link"
+          href="#docs"
+          variant="inline"
+          startIcon={<i data-testid="start-icon" aria-hidden="true" />}
+        />,
+      );
+
+      expect(screen.queryByTestId('start-icon')).not.toBeInTheDocument();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Link: `inline` variant supports endIcon only. Ignoring startIcon.',
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('prefers endIcon for inline variant when both icons are passed', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      render(
+        <Link
+          label="Inline link"
+          href="#docs"
+          variant="inline"
+          startIcon={<i data-testid="start-icon" aria-hidden="true" />}
+          endIcon={<i data-testid="end-icon" aria-hidden="true" />}
+        />,
+      );
+
+      expect(screen.queryByTestId('start-icon')).not.toBeInTheDocument();
+      expect(screen.getByTestId('end-icon')).toBeInTheDocument();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Link: `inline` variant supports endIcon only. Ignoring startIcon.',
+      );
+      expect(warnSpy).not.toHaveBeenCalledWith(
         'Link: pass either startIcon or endIcon, not both. Rendering startIcon only.',
       );
 

--- a/components/link/Link.tsx
+++ b/components/link/Link.tsx
@@ -1,7 +1,7 @@
 import type { AnchorHTMLAttributes, MouseEvent, ReactElement } from 'react';
 import { forwardRef, isValidElement } from 'react';
 
-type LinkVariant = 'primary' | 'secondary';
+type LinkVariant = 'primary' | 'secondary' | 'inline';
 
 type IconElement = ReactElement<'i' | 'svg'>;
 
@@ -13,7 +13,7 @@ export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   endIcon?: IconElement;
 }
 
-const allowedVariants: LinkVariant[] = ['primary', 'secondary'];
+const allowedVariants: LinkVariant[] = ['primary', 'secondary', 'inline'];
 
 const isIconElement = (el: unknown, propName: string): el is IconElement => {
   const valid = isValidElement(el) && (el.type === 'i' || el.type === 'svg');
@@ -49,6 +49,14 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     ? startIcon
     : null;
   const resolvedEndIcon = isIconElement(endIcon, 'endIcon') ? endIcon : null;
+  const isInlineVariant = resolvedVariant === 'inline';
+  const hasStartIcon = resolvedStartIcon !== null;
+  const hasEndIcon = resolvedEndIcon !== null;
+
+  const renderedStartIcon =
+    !isInlineVariant && hasStartIcon ? resolvedStartIcon : null;
+  const renderedEndIcon =
+    isInlineVariant || !hasStartIcon ? resolvedEndIcon : null;
 
   if (import.meta.env.DEV) {
     const hasAccessibleName =
@@ -68,7 +76,13 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       );
     }
 
-    if (resolvedStartIcon && resolvedEndIcon) {
+    if (isInlineVariant && hasStartIcon) {
+      console.warn(
+        'Link: `inline` variant supports endIcon only. Ignoring startIcon.',
+      );
+    }
+
+    if (!isInlineVariant && hasStartIcon && hasEndIcon) {
       console.warn(
         'Link: pass either startIcon or endIcon, not both. Rendering startIcon only.',
       );
@@ -119,15 +133,15 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       role={disabled ? (role ?? 'link') : role}
       onClick={handleClick}
     >
-      {resolvedStartIcon ? (
+      {renderedStartIcon ? (
         <span className="mds-link__icon" aria-hidden="true">
-          {resolvedStartIcon}
+          {renderedStartIcon}
         </span>
       ) : null}
       <span className="mds-link__label">{label}</span>
-      {resolvedStartIcon ? null : resolvedEndIcon ? (
+      {renderedEndIcon ? (
         <span className="mds-link__icon" aria-hidden="true">
-          {resolvedEndIcon}
+          {renderedEndIcon}
         </span>
       ) : null}
     </a>

--- a/components/link/link.css
+++ b/components/link/link.css
@@ -79,6 +79,25 @@
   color: var(--mds-text-default);
 }
 
+/* Inline links stay underlined at rest and inherit surrounding paragraph type. */
+.mds-link[class].mds-link--inline {
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: inherit;
+  letter-spacing: inherit;
+}
+
+.mds-link[class].mds-link--inline .mds-link__label {
+  text-decoration: underline;
+  text-decoration-thickness: from-font;
+  text-underline-position: from-font;
+}
+
+/* Inline focus uses only the focus stroke (no stacked underline). */
+.mds-link[class].mds-link--inline:focus-visible .mds-link__label {
+  text-decoration: none;
+}
+
 .mds-link[class].mds-link--disabled,
 .mds-link[class].mds-link--disabled:hover,
 .mds-link[class].mds-link--disabled:active {


### PR DESCRIPTION
## Description

Adds a new Inline variant to Link for in-paragraph usage, based on the updated Figma component at node 10843:763.

Key changes:
- Added inline as a supported Link variant.
- Implemented inline visual behavior: underline is visible at rest.
- Applied inline typography inheritance so links blend correctly with surrounding paragraph text.
- Updated Link stories to include inline usage and matrix coverage.
- Added unit test coverage for inline variant class behavior.
- Updated Code Connect mappings to include explicit Variant-scoped entries for Primary, Secondary, and Inline to avoid overlap and improve mapping clarity.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-650

## Type of Change

- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

Storybook stories updated for visual verification:
- Components/Link/Variants
- Components/Link/Inline In Paragraph
- Components/Link/State Matrix

Figma reference:
- https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?m=dev&node-id=10843-763

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

Accessibility notes:
- Inline remains a semantic anchor and keeps keyboard/focus behavior.
- Disabled behavior remains enforced via aria-disabled and click prevention.