### PR TITLE
feat(Textarea): Add new Textarea component

### DIFF
--- a/.github/instructions/component-index.instructions.md
+++ b/.github/instructions/component-index.instructions.md
@@ -8,26 +8,27 @@ Quick reference for AI agents and developers.
 
 ## Components
 
-| Component       | Purpose                                                                                   | Key props                                         |
-| --------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| ActivityIcon    | Activity/resource/file icon with semantic category styling                                | icon, category, size, container                   |
-| Alert           | Persistent inline status banner with semantic variants and optional actions/dismiss       | type, title, message, isDismissible, isActionable |
-| Avatar          | Circular user/entity identity display — photo or initials                                 | type, size, initials, imageSrc, imageAlt          |
-| Badge           | Short status, metadata, or count labels                                                   | type, contrast, style, icon, label                |
-| Breadcrumb      | Hierarchical page trail with truncation and overflow support                              | items, ariaLabel, overflowAriaLabel               |
-| Button          | Primary and secondary actions                                                             | variant, size, disabled, startIcon, endIcon       |
-| Checkbox        | Independent multi-select controls                                                         | checked, label, disabled, invalid, indeterminate  |
-| Choicebox       | Single-select options as larger, card-style choices (icon + label + supporting text)      | checked, label, disabled, invalid                 |
-| CloseButton     | Icon-only dismiss action for temporary UI surfaces                                        | size, disabled, ariaLabel                         |
-| Dropdown        | Composable trigger + menu container for action, select, expandable, and multiselect items | label, variant, appearance, size, open, children  |
-| FavouriteButton | Icon button to mark/unmark items as favourites                                            | checked, size, disabled, ariaLabel                |
-| Link            | Anchor element with variant and optional icon support                                     | label, variant, disabled, startIcon, endIcon      |
-| NavPill         | Compact pill-style navigation link for section switching                                  | label, active, disabled, href, ariaLabel          |
-| Pagination      | Page navigation control                                                                   | totalPages, currentPage, onPageChange, ariaLabel  |
-| ProgressBar     | Visual progress indicator with status and label variants                                  | value, min, max, status, labelVariant, title      |
-| Radio           | Single-select options in a compact list (native radio input, label only)                  | checked, label, disabled, invalid                 |
-| Switch          | Binary toggle control for on/off settings                                                 | checked, label, disabled, onChange                |
-| Tooltip         | Contextual label anchored to a trigger element                                            | label, placement, variant, children               |
+| Component       | Purpose                                                                                   | Key props                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| ActivityIcon    | Activity/resource/file icon with semantic category styling                                | icon, category, size, container                                         |
+| Alert           | Persistent inline status banner with semantic variants and optional actions/dismiss       | type, title, message, isDismissible, isActionable                       |
+| Avatar          | Circular user/entity identity display — photo or initials                                 | type, size, initials, imageSrc, imageAlt                                |
+| Badge           | Short status, metadata, or count labels                                                   | type, contrast, style, icon, label                                      |
+| Breadcrumb      | Hierarchical page trail with truncation and overflow support                              | items, ariaLabel, overflowAriaLabel                                     |
+| Button          | Primary and secondary actions                                                             | variant, size, disabled, startIcon, endIcon                             |
+| Checkbox        | Independent multi-select controls                                                         | checked, label, disabled, invalid, indeterminate                        |
+| Choicebox       | Single-select options as larger, card-style choices (icon + label + supporting text)      | checked, label, disabled, invalid                                       |
+| CloseButton     | Icon-only dismiss action for temporary UI surfaces                                        | size, disabled, ariaLabel                                               |
+| Dropdown        | Composable trigger + menu container for action, select, expandable, and multiselect items | label, variant, appearance, size, open, children                        |
+| FavouriteButton | Icon button to mark/unmark items as favourites                                            | checked, size, disabled, ariaLabel                                      |
+| Link            | Anchor element with variant and optional icon support                                     | label, variant, disabled, startIcon, endIcon                            |
+| NavPill         | Compact pill-style navigation link for section switching                                  | label, active, disabled, href, ariaLabel                                |
+| Pagination      | Page navigation control                                                                   | totalPages, currentPage, onPageChange, ariaLabel                        |
+| ProgressBar     | Visual progress indicator with status and label variants                                  | value, min, max, status, labelVariant, title                            |
+| Radio           | Single-select options in a compact list (native radio input, label only)                  | checked, label, disabled, invalid                                       |
+| Switch          | Binary toggle control for on/off settings                                                 | checked, label, disabled, onChange                                      |
+| Textarea        | Multi-line text input with label, supporting text, counter, and validation                | label, invalid, invalidFeedback, supportingText, showCounter, resizable |
+| Tooltip         | Contextual label anchored to a trigger element                                            | label, placement, variant, children                                     |
 
 ## Dropdown Subcomponents
 
@@ -101,6 +102,8 @@ Use these as building blocks inside `Dropdown` and `DropdownMenu`.
 - [Radio stories](../../components/radio/Radio.stories.tsx)
 - [Switch implementation](../../components/switch/Switch.tsx)
 - [Switch stories](../../components/switch/Switch.stories.tsx)
+- [Textarea implementation](../../components/textarea/Textarea.tsx)
+- [Textarea stories](../../components/textarea/Textarea.stories.tsx)
 - [Tooltip implementation](../../components/tooltip/Tooltip.tsx)
 - [Tooltip stories](../../components/tooltip/Tooltip.stories.tsx)
 

--- a/components/index.css
+++ b/components/index.css
@@ -15,4 +15,5 @@
 @import './progress-bar/progress-bar.css';
 @import './radio/radio.css';
 @import './switch/switch.css';
+@import './textarea/textarea.css';
 @import './tooltip/tooltip.css';

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -73,5 +73,8 @@ export type { RadioProps } from './radio';
 export { Switch } from './switch';
 export type { SwitchProps } from './switch';
 
+export { Textarea } from './textarea';
+export type { TextareaProps } from './textarea';
+
 export { Tooltip } from './tooltip';
 export type { TooltipProps } from './tooltip';

--- a/components/textarea/Textarea.figma.tsx
+++ b/components/textarea/Textarea.figma.tsx
@@ -1,0 +1,136 @@
+import figma from '@figma/code-connect';
+import { Textarea } from './Textarea';
+
+const url =
+  'https://www.figma.com/design/bPRkRtSszcbWw9f9p9rXvA/Moodle-Design-System?node-id=13934-4878';
+
+const baseProps = {
+  label: figma.string('Supporting text#13940:21'),
+  required: figma.boolean('Required#13940:15'),
+  // "Show Label" is the inverse of hideLabel
+  hideLabel: figma.boolean('Show Label#13940:13', { true: false, false: true }),
+  resizable: figma.boolean('Resizable#13963:21'),
+  infoTooltipLabel: figma.boolean('Info#13950:34', {
+    true: 'Additional information about this field',
+    false: undefined,
+  }),
+};
+
+// Default state
+figma.connect(Textarea, url, {
+  variant: { State: 'default' },
+  props: baseProps,
+  example: ({ label, hideLabel, required, resizable, infoTooltipLabel }) => (
+    <Textarea
+      label={label}
+      hideLabel={hideLabel}
+      required={required}
+      resizable={resizable}
+      infoTooltipLabel={infoTooltipLabel}
+      placeholder="Placeholder text goes here"
+    />
+  ),
+});
+
+// Default state with supporting text
+figma.connect(Textarea, url, {
+  variant: { State: 'default', 'Support text': 'yes' },
+  props: baseProps,
+  example: ({ label, hideLabel, required, resizable, infoTooltipLabel }) => (
+    <Textarea
+      label={label}
+      hideLabel={hideLabel}
+      required={required}
+      resizable={resizable}
+      infoTooltipLabel={infoTooltipLabel}
+      placeholder="Placeholder text goes here"
+      supportingText="Supporting text"
+    />
+  ),
+});
+
+// Default state with counter
+figma.connect(Textarea, url, {
+  variant: { State: 'default', Counter: 'yes' },
+  props: baseProps,
+  example: ({ label, hideLabel, required, resizable, infoTooltipLabel }) => (
+    <Textarea
+      label={label}
+      hideLabel={hideLabel}
+      required={required}
+      resizable={resizable}
+      infoTooltipLabel={infoTooltipLabel}
+      placeholder="Placeholder text goes here"
+      showCounter
+      maxLength={100}
+    />
+  ),
+});
+
+// Invalid state without feedback text
+figma.connect(Textarea, url, {
+  variant: { State: 'invalid', 'Support text': 'no' },
+  props: baseProps,
+  example: ({ label, hideLabel, required, resizable, infoTooltipLabel }) => (
+    <Textarea
+      label={label}
+      hideLabel={hideLabel}
+      required={required}
+      resizable={resizable}
+      infoTooltipLabel={infoTooltipLabel}
+      placeholder="Placeholder text goes here"
+      invalid
+    />
+  ),
+});
+
+// Invalid state with feedback text
+figma.connect(Textarea, url, {
+  variant: { State: 'invalid', 'Support text': 'yes' },
+  props: baseProps,
+  example: ({ label, hideLabel, required, resizable, infoTooltipLabel }) => (
+    <Textarea
+      label={label}
+      hideLabel={hideLabel}
+      required={required}
+      resizable={resizable}
+      infoTooltipLabel={infoTooltipLabel}
+      placeholder="Placeholder text goes here"
+      invalid
+      invalidFeedback="Error message"
+    />
+  ),
+});
+
+// Disabled state
+figma.connect(Textarea, url, {
+  variant: { State: 'disabled' },
+  props: baseProps,
+  example: ({ label, hideLabel, required, infoTooltipLabel }) => (
+    <Textarea
+      label={label}
+      hideLabel={hideLabel}
+      required={required}
+      infoTooltipLabel={infoTooltipLabel}
+      placeholder="Placeholder text goes here"
+      disabled
+    />
+  ),
+});
+
+// Read-only state
+figma.connect(Textarea, url, {
+  variant: { State: 'read-only' },
+  props: baseProps,
+  example: ({ label, hideLabel, required, resizable, infoTooltipLabel }) => (
+    <Textarea
+      label={label}
+      hideLabel={hideLabel}
+      required={required}
+      resizable={resizable}
+      infoTooltipLabel={infoTooltipLabel}
+      readOnly
+      defaultValue="Lorem ipsum dolor sit amet"
+    />
+  ),
+});

--- a/components/textarea/Textarea.stories.tsx
+++ b/components/textarea/Textarea.stories.tsx
@@ -1,0 +1,391 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+import { Textarea } from './Textarea';
+
+const meta = {
+  title: 'Components/Textarea',
+  component: Textarea,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs', 'test', 'stable'],
+  decorators: [
+    (Story) => (
+      <div style={{ width: 'min(395px, 95vw)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    placeholder: {
+      description: 'Placeholder text shown when the field is empty.',
+      control: { type: 'text' },
+    },
+    label: {
+      description: 'Visible label text above the field.',
+      control: { type: 'text' },
+    },
+    hideLabel: {
+      description:
+        'When true, hides the visible label. Provide an accessible name via aria-label or label prop.',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'false' } },
+    },
+    required: {
+      description: 'Marks the field as required. Appends a * to the label.',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'false' } },
+    },
+    invalid: {
+      description:
+        'Marks the field as invalid — applies danger border styling and sets aria-invalid.',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'false' } },
+    },
+    invalidFeedback: {
+      description:
+        'Pre-translated error message shown below the field when invalid is true.',
+      control: { type: 'text' },
+      if: { arg: 'invalid', truthy: true },
+    },
+    supportingText: {
+      description: 'Helper text shown below the field in non-error state.',
+      control: { type: 'text' },
+    },
+    infoTooltipLabel: {
+      description:
+        'Accessible label for the info tooltip button shown beside the visible label.',
+      control: { type: 'text' },
+      if: { arg: 'hideLabel', eq: false },
+    },
+    showCounter: {
+      description:
+        'Shows a live character counter. Requires maxLength to be set.',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'false' } },
+      if: { arg: 'maxLength', exists: true },
+    },
+    counterAriaLabel: {
+      description:
+        'Optional i18n text (static string) or formatter for the counter aria-label. Formatter receives (currentLength, maxLength). The control only accepts a static string; use the args/code editor to pass a formatter function.',
+      control: { type: 'text' },
+      table: {
+        type: {
+          summary:
+            'string | ((currentLength: number, maxLength: number) => string)',
+        },
+      },
+    },
+    counterRemainingAnnouncement: {
+      description:
+        'Optional i18n text (static string) or formatter for remaining-character milestone announcements. Formatter receives (remaining, maxLength). The control only accepts a static string; use the args/code editor to pass a formatter function.',
+      control: { type: 'text' },
+      table: {
+        type: {
+          summary:
+            'string | ((remaining: number, maxLength: number) => string)',
+        },
+      },
+    },
+    counterOverLimitAnnouncement: {
+      description:
+        'Optional i18n text (static string) or formatter for over-limit announcements. Formatter receives (overLimitBy, maxLength). The control only accepts a static string; use the args/code editor to pass a formatter function.',
+      control: { type: 'text' },
+      table: {
+        type: {
+          summary:
+            'string | ((overLimitBy: number, maxLength: number) => string)',
+        },
+      },
+    },
+    resizable: {
+      description:
+        'When true (default), the textarea can be resized vertically by the user.',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'true' } },
+    },
+    disabled: {
+      description:
+        'Use when input is unavailable. Pair with supportingText to explain why the field is disabled.',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'false' } },
+    },
+    readOnly: {
+      description:
+        'Use when existing content should stay readable/copyable while editing is blocked.',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'false' } },
+    },
+    maxLength: {
+      description:
+        'Maximum number of characters. Provide a non-negative integer (0 allowed). Clear/reset this control to remove the limit and hide showCounter.',
+      control: { type: 'number', min: 0, step: 1 },
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+    rows: {
+      description: 'The number of visible text lines.',
+      control: { type: 'number' },
+    },
+  },
+  args: {
+    placeholder: 'Placeholder text goes here',
+    label: 'Label text',
+    hideLabel: false,
+    required: false,
+    invalid: false,
+    showCounter: false,
+    resizable: true,
+    disabled: false,
+    readOnly: false,
+    rows: 3,
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: 'Label text',
+    placeholder: 'Placeholder text goes here',
+  },
+};
+
+export const WithSupportingText: Story = {
+  args: {
+    label: 'Label text',
+    placeholder: 'Placeholder text goes here',
+    supportingText: 'Supporting text',
+  },
+};
+
+export const WithCounter: Story = {
+  render: function Render(args) {
+    const [value, setValue] = useState('');
+    return (
+      <Textarea
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+  args: {
+    label: 'Label text',
+    placeholder: 'Placeholder text goes here',
+    showCounter: true,
+    maxLength: 100,
+  },
+};
+
+export const WithSupportingTextAndCounter: Story = {
+  render: function Render(args) {
+    const [value, setValue] = useState('');
+    return (
+      <Textarea
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+  args: {
+    label: 'Label text',
+    placeholder: 'Placeholder text goes here',
+    supportingText: 'Supporting text',
+    showCounter: true,
+    maxLength: 100,
+  },
+};
+
+export const WithInfoButton: Story = {
+  args: {
+    label: 'Course description',
+    placeholder: 'Describe the course aims and outcomes…',
+    infoTooltipLabel:
+      'Enter a brief overview of what learners will gain from this course.',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: 'Label text',
+    required: true,
+    placeholder: 'Placeholder text goes here',
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    label: 'Label text',
+    invalid: true,
+    invalidFeedback: 'This field is required.',
+    placeholder: 'Placeholder text goes here',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(canvas.getByText('This field is required.')).toBeInTheDocument();
+  },
+};
+
+export const InvalidWithCounter: Story = {
+  render: function Render(args) {
+    const [value, setValue] = useState('');
+    return (
+      <Textarea
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+  args: {
+    label: 'Label text',
+    invalid: true,
+    invalidFeedback: 'This field is required.',
+    showCounter: true,
+    maxLength: 100,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Label text',
+    disabled: true,
+    placeholder: 'Placeholder text goes here',
+    supportingText: 'Supporting text',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole('textbox')).toBeDisabled();
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    label: 'Label text',
+    readOnly: true,
+    defaultValue:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    supportingText: 'Supporting text',
+    showCounter: true,
+    maxLength: 100,
+  },
+};
+
+export const NonResizable: Story = {
+  args: {
+    label: 'Label text',
+    resizable: false,
+    placeholder: 'Placeholder text goes here',
+    supportingText: 'This textarea cannot be resized.',
+  },
+};
+
+export const HiddenLabel: Story = {
+  args: {
+    label: 'Description',
+    hideLabel: true,
+    placeholder: 'Enter your description',
+  },
+};
+
+export const LiveCharacterCount: Story = {
+  render: function Render(args) {
+    const [value, setValue] = useState('');
+    return (
+      <Textarea
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+  args: {
+    label: 'Message',
+    placeholder: 'Type here…',
+    showCounter: true,
+    maxLength: 50,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+    await userEvent.type(textarea, 'Hello');
+    await expect(canvas.getByText('5 / 50')).toBeInTheDocument();
+  },
+};
+
+export const LocalizedCounterAccessibility: Story = {
+  render: function Render(args) {
+    const [value, setValue] = useState('');
+    return (
+      <Textarea
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+  args: {
+    label: 'Nachricht',
+    placeholder: 'Hier schreiben…',
+    showCounter: true,
+    maxLength: 20,
+    counterAriaLabel: (current, max) =>
+      `${current} von ${max} Zeichen verwendet`,
+    counterRemainingAnnouncement: (remaining, max) =>
+      `${remaining} von ${max} Zeichen verbleibend`,
+    counterOverLimitAnnouncement: (over, max) =>
+      `${over} über dem Limit von ${max} Zeichen`,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+    await userEvent.type(textarea, '123456789012345');
+    await expect(canvas.getByText('15 / 20')).toHaveAttribute(
+      'aria-label',
+      '15 von 20 Zeichen verwendet',
+    );
+    await expect(canvas.getByRole('status')).toHaveTextContent(
+      '5 von 20 Zeichen verbleibend',
+    );
+  },
+};
+
+export const RightToLeft: Story = {
+  tags: ['test', 'stable'],
+  args: {
+    label: 'نص التسمية',
+    placeholder: 'اكتب النص هنا',
+    required: true,
+    invalid: true,
+    invalidFeedback: 'هذا الحقل مطلوب',
+    infoTooltipLabel: 'معلومات إضافية حول هذا الحقل',
+    showCounter: true,
+    maxLength: 100,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+    await expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    await expect(
+      canvas.getByRole('button', { name: 'معلومات إضافية حول هذا الحقل' }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('هذا الحقل مطلوب')).toBeInTheDocument();
+    await userEvent.type(textarea, 'مرحبا');
+    await expect(textarea).toHaveValue('مرحبا');
+    await expect(canvas.getByText('5 / 100')).toBeInTheDocument();
+  },
+  decorators: [
+    (Story) => (
+      <div dir="rtl">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/components/textarea/Textarea.test.tsx
+++ b/components/textarea/Textarea.test.tsx
@@ -1,0 +1,590 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Textarea } from './Textarea';
+
+describe('Textarea: Unit Test', () => {
+  it('applies mds-textarea class to the wrapper', () => {
+    const { container } = render(<Textarea label="Description" />);
+    expect(container.firstChild).toHaveClass('mds-textarea');
+  });
+
+  it('applies mds-textarea-field class to the textarea element', () => {
+    render(<Textarea label="Description" />);
+    expect(screen.getByRole('textbox')).toHaveClass('mds-textarea-field');
+  });
+
+  it('applies form-control class to the textarea element', () => {
+    render(<Textarea label="Description" />);
+    expect(screen.getByRole('textbox')).toHaveClass('form-control');
+  });
+
+  it('renders the label text', () => {
+    render(<Textarea label="My field" />);
+    expect(screen.getByText('My field')).toBeInTheDocument();
+  });
+
+  it('associates the label with the textarea via htmlFor', () => {
+    render(<Textarea label="My field" />);
+    expect(screen.getByLabelText('My field')).toBeInTheDocument();
+  });
+
+  it('hides the label when hideLabel is true', () => {
+    render(<Textarea label="Hidden" hideLabel />);
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+  });
+
+  it('renders invalidFeedback when hideLabel is true', () => {
+    render(
+      <Textarea
+        label="Field"
+        hideLabel
+        invalid
+        invalidFeedback="Error message"
+      />,
+    );
+    expect(screen.getByText('Error message')).toBeInTheDocument();
+  });
+
+  it('uses aria-label from label prop when hideLabel is true', () => {
+    render(<Textarea label="Hidden label" hideLabel />);
+    expect(
+      screen.getByRole('textbox', { name: 'Hidden label' }),
+    ).toBeInTheDocument();
+  });
+
+  it('prefers explicit aria-label over label prop when hideLabel is true', () => {
+    render(
+      <Textarea label="Label prop" hideLabel aria-label="Explicit label" />,
+    );
+    expect(
+      screen.getByRole('textbox', { name: 'Explicit label' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the required asterisk when required is true', () => {
+    render(<Textarea label="Required field" required />);
+    const label = screen.getByText('Required field').closest('label');
+    expect(label).toBeInTheDocument();
+
+    const requiredIndicator = within(label as HTMLLabelElement).getByText('*');
+    expect(requiredIndicator).toBeInTheDocument();
+    expect(requiredIndicator).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('does not render the asterisk when required is false', () => {
+    render(<Textarea label="Optional field" />);
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+
+  it('applies is-invalid class when invalid is true', () => {
+    render(<Textarea label="Field" invalid />);
+    expect(screen.getByRole('textbox')).toHaveClass('is-invalid');
+  });
+
+  it('does not apply is-invalid class when invalid is false', () => {
+    render(<Textarea label="Field" />);
+    expect(screen.getByRole('textbox')).not.toHaveClass('is-invalid');
+  });
+
+  it('sets aria-invalid when invalid is true', () => {
+    render(<Textarea label="Field" invalid />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not set aria-invalid when invalid is false', () => {
+    render(<Textarea label="Field" />);
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('renders invalidFeedback when invalid is true', () => {
+    render(<Textarea label="Field" invalid invalidFeedback="Error message" />);
+    expect(screen.getByText('Error message')).toBeInTheDocument();
+  });
+
+  it('does not render invalidFeedback when invalid is false', () => {
+    render(<Textarea label="Field" invalidFeedback="Error message" />);
+    expect(screen.queryByText('Error message')).not.toBeInTheDocument();
+  });
+
+  it('associates the feedback text with the textarea via aria-describedby', () => {
+    render(<Textarea label="Field" invalid invalidFeedback="Error message" />);
+    const textarea = screen.getByRole('textbox');
+    const feedbackId = textarea.getAttribute('aria-describedby');
+    expect(feedbackId).toBeTruthy();
+    expect(document.getElementById(feedbackId!)).toHaveTextContent(
+      'Error message',
+    );
+  });
+
+  it('renders supportingText in the footer', () => {
+    render(<Textarea label="Field" supportingText="Helper text" />);
+    expect(screen.getByText('Helper text')).toBeInTheDocument();
+  });
+
+  it('does not render supportingText when invalid+invalidFeedback is shown', () => {
+    render(
+      <Textarea
+        label="Field"
+        invalid
+        invalidFeedback="Error"
+        supportingText="Helper"
+      />,
+    );
+    expect(screen.queryByText('Helper')).not.toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  it('renders the counter when showCounter and maxLength are provided', () => {
+    render(
+      <Textarea label="Field" showCounter maxLength={100} defaultValue="" />,
+    );
+    expect(screen.getByText('0 / 100')).toBeInTheDocument();
+  });
+
+  it('does not render the counter when showCounter is false', () => {
+    render(<Textarea label="Field" maxLength={100} />);
+    expect(screen.queryByText('0 / 100')).not.toBeInTheDocument();
+  });
+
+  it('updates counter display when value changes (controlled)', async () => {
+    const { rerender } = render(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={100}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('0 / 100')).toBeInTheDocument();
+    rerender(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={100}
+        value="Hello"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('5 / 100')).toBeInTheDocument();
+  });
+
+  it('updates counter display when typing into an uncontrolled textarea', async () => {
+    const user = userEvent.setup();
+    render(<Textarea label="Field" showCounter maxLength={100} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'Hello');
+
+    expect(screen.getByText('5 / 100')).toBeInTheDocument();
+  });
+
+  it('applies custom counter aria-label formatter when provided', () => {
+    render(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={100}
+        value="hello"
+        onChange={() => {}}
+        counterAriaLabel={(current, max) =>
+          `${current} von ${max} Zeichen verwendet`
+        }
+      />,
+    );
+
+    expect(screen.getByText('5 / 100')).toHaveAttribute(
+      'aria-label',
+      '5 von 100 Zeichen verwendet',
+    );
+  });
+
+  it('does not add default English aria-label when no formatter is provided', () => {
+    render(<Textarea label="Field" showCounter maxLength={100} />);
+    expect(screen.getByText('0 / 100')).not.toHaveAttribute('aria-label');
+  });
+
+  it('announces remaining-character milestones using custom formatter', async () => {
+    const user = userEvent.setup();
+    render(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={10}
+        counterRemainingAnnouncement={(remaining, max) =>
+          `Il reste ${remaining} sur ${max}`
+        }
+      />,
+    );
+
+    await user.type(screen.getByRole('textbox'), 'abcde');
+
+    expect(screen.getByRole('status')).toHaveTextContent('Il reste 5 sur 10');
+  });
+
+  it('announces over-limit text using custom formatter', () => {
+    const { rerender } = render(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={5}
+        value="abcde"
+        onChange={() => {}}
+        counterOverLimitAnnouncement={(over, max) =>
+          `${over} au-dessus de la limite de ${max}`
+        }
+      />,
+    );
+
+    rerender(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={5}
+        value="abcdef"
+        onChange={() => {}}
+        counterOverLimitAnnouncement={(over, max) =>
+          `${over} au-dessus de la limite de ${max}`
+        }
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '1 au-dessus de la limite de 5',
+    );
+  });
+
+  it('applies mds-textarea-field--no-resize class when resizable is false', () => {
+    render(<Textarea label="Field" resizable={false} />);
+    expect(screen.getByRole('textbox')).toHaveClass(
+      'mds-textarea-field--no-resize',
+    );
+  });
+
+  it('does not apply no-resize class when resizable is true', () => {
+    render(<Textarea label="Field" resizable />);
+    expect(screen.getByRole('textbox')).not.toHaveClass(
+      'mds-textarea-field--no-resize',
+    );
+  });
+
+  it('disables the textarea when disabled is true', () => {
+    render(<Textarea label="Field" disabled />);
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('makes textarea read-only when readOnly is true', () => {
+    render(<Textarea label="Field" readOnly />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('readonly');
+  });
+
+  it('forwards extra props to the underlying textarea element', () => {
+    render(<Textarea label="Field" data-testid="my-textarea" />);
+    expect(screen.getByTestId('my-textarea')).toBeInTheDocument();
+  });
+
+  it('appends consumer className to the wrapper', () => {
+    const { container } = render(
+      <Textarea label="Field" className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass('mds-textarea', 'custom-class');
+  });
+
+  it('uses provided id on the textarea', () => {
+    render(<Textarea label="Field" id="my-id" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'my-id');
+    expect(screen.getByText('Field').closest('label')).toHaveAttribute(
+      'for',
+      'my-id',
+    );
+  });
+
+  it('forwards ref to the underlying textarea element', () => {
+    const ref = createRef<HTMLTextAreaElement>();
+    render(<Textarea label="Field" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+  });
+
+  it('does not render the footer row when no footer content is needed', () => {
+    const { container } = render(<Textarea label="Field" />);
+    expect(container.querySelector('.mds-textarea-footer')).toBeNull();
+  });
+
+  it('warns in dev mode when hideLabel is true without a label', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<Textarea hideLabel />);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('label prop or aria-label attribute is required'),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('warns in dev mode when showCounter is true without maxLength', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<Textarea label="Field" showCounter />);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('showCounter=true requires maxLength'),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('warns in dev mode when disabled is true without supportingText', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<Textarea label="Field" disabled />);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'disabled fields should include supportingText that explains why input is unavailable',
+      ),
+    );
+    vi.restoreAllMocks();
+  });
+
+  describe('Textarea: supportingText visible when hideLabel is true', () => {
+    it('renders supportingText even when hideLabel is true', () => {
+      render(<Textarea label="Field" hideLabel supportingText="Helper" />);
+      expect(screen.getByText('Helper')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the info tooltip button when infoTooltipLabel is provided', () => {
+    render(<Textarea label="Field" infoTooltipLabel="More about this field" />);
+    expect(
+      screen.getByRole('button', { name: 'More about this field' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the info button when hideLabel is true', () => {
+    render(
+      <Textarea
+        label="Field"
+        hideLabel
+        aria-label="Field"
+        infoTooltipLabel="More about this field"
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: 'More about this field' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the invalid icon when invalid is true', () => {
+    const { container } = render(<Textarea label="Field" invalid />);
+    expect(
+      container.querySelector('.mds-textarea-invalid-icon'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the invalid icon when invalid is false', () => {
+    const { container } = render(<Textarea label="Field" />);
+    expect(
+      container.querySelector('.mds-textarea-invalid-icon'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not set aria-readonly, relying on the native readonly attribute', () => {
+    render(<Textarea label="Field" readOnly />);
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-readonly');
+  });
+
+  it('links counter to textarea via aria-describedby when showCounter and maxLength are set', () => {
+    render(<Textarea label="Field" showCounter maxLength={100} />);
+    const textarea = screen.getByRole('textbox');
+    const describedBy = textarea.getAttribute('aria-describedby') ?? '';
+    expect(describedBy).not.toBe('');
+    const counterEl = document.getElementById(describedBy.split(' ').at(-1)!);
+    expect(counterEl).toHaveTextContent('0 / 100');
+  });
+
+  it('includes both feedback id and counter id in aria-describedby', () => {
+    render(
+      <Textarea
+        label="Field"
+        invalid
+        invalidFeedback="Error"
+        showCounter
+        maxLength={100}
+      />,
+    );
+    const textarea = screen.getByRole('textbox');
+    const describedBy = textarea.getAttribute('aria-describedby') ?? '';
+    const ids = describedBy.split(' ');
+    expect(ids.length).toBe(2);
+    expect(document.getElementById(ids[0])).toHaveTextContent('Error');
+    expect(document.getElementById(ids[1])).toHaveTextContent('0 / 100');
+  });
+
+  it('merges consumer aria-describedby with generated ids', () => {
+    render(
+      <>
+        <span id="external-hint">External hint</span>
+        <Textarea
+          label="Field"
+          aria-describedby="external-hint"
+          invalid
+          invalidFeedback="Error"
+          showCounter
+          maxLength={100}
+        />
+      </>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    const describedBy = textarea.getAttribute('aria-describedby') ?? '';
+    const ids = describedBy.split(' ');
+
+    expect(ids).toContain('external-hint');
+    expect(ids.length).toBe(3);
+    expect(document.getElementById('external-hint')).toHaveTextContent(
+      'External hint',
+    );
+    expect(document.getElementById(ids[1])).toHaveTextContent('Error');
+    expect(document.getElementById(ids[2])).toHaveTextContent('0 / 100');
+  });
+
+  it('links hidden-label invalid feedback via aria-describedby', () => {
+    render(
+      <Textarea
+        hideLabel
+        aria-label="Field"
+        invalid
+        invalidFeedback="Hidden label error"
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Field' });
+    const feedbackId = textarea.getAttribute('aria-describedby');
+
+    expect(screen.queryByText('Field')).not.toBeInTheDocument();
+    expect(feedbackId).toBeTruthy();
+    expect(document.getElementById(feedbackId!)).toHaveTextContent(
+      'Hidden label error',
+    );
+  });
+
+  it('merges consumer aria-describedby when hideLabel is true', () => {
+    render(
+      <>
+        <span id="external-description">External description</span>
+        <Textarea
+          hideLabel
+          aria-label="Field"
+          aria-describedby="external-description"
+          invalid
+          invalidFeedback="Error"
+        />
+      </>,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Field' });
+    const describedBy = textarea.getAttribute('aria-describedby') ?? '';
+    const ids = describedBy.split(' ');
+
+    expect(ids).toContain('external-description');
+    expect(ids.length).toBe(2);
+    expect(document.getElementById('external-description')).toHaveTextContent(
+      'External description',
+    );
+    expect(document.getElementById(ids[1])).toHaveTextContent('Error');
+  });
+
+  it('only applies pointer-focus class for pointer-initiated focus', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type="button">Before</button>
+        <Textarea label="Field" />
+      </>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+
+    await user.tab();
+    await user.tab();
+    expect(textarea).toHaveFocus();
+    expect(textarea).not.toHaveClass('mds-textarea-field--pointer-focus');
+
+    fireEvent.blur(textarea);
+    fireEvent.pointerDown(textarea);
+    fireEvent.focus(textarea);
+
+    expect(textarea).toHaveClass('mds-textarea-field--pointer-focus');
+
+    fireEvent.blur(textarea);
+    expect(textarea).not.toHaveClass('mds-textarea-field--pointer-focus');
+  });
+
+  it('keeps no-resize behavior when readOnly is enabled', () => {
+    render(<Textarea label="Field" readOnly resizable={false} />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveClass('mds-textarea-field--readonly');
+    expect(textarea).toHaveClass('mds-textarea-field--no-resize');
+    expect(textarea).toHaveAttribute('readonly');
+  });
+
+  it('shows supporting guidance instead of invalid feedback when disabled', () => {
+    render(
+      <Textarea
+        label="Field"
+        disabled
+        invalid
+        invalidFeedback="Error message"
+        supportingText="Guidance text"
+      />,
+    );
+
+    expect(screen.getByText('Guidance text')).toBeInTheDocument();
+    expect(screen.queryByText('Error message')).not.toBeInTheDocument();
+  });
+
+  it('shows controlled values above maxLength in the counter display', () => {
+    const { rerender } = render(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={5}
+        value="abcde"
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('5 / 5')).toBeInTheDocument();
+
+    rerender(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={5}
+        value="abcdef"
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('6 / 5')).toBeInTheDocument();
+  });
+
+  it('announces milestone text only when a threshold is crossed', async () => {
+    const user = userEvent.setup();
+    render(
+      <Textarea
+        label="Field"
+        showCounter
+        maxLength={25}
+        counterRemainingAnnouncement={(remaining, max) =>
+          `${remaining} characters left out of ${max}`
+        }
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    const status = screen.getByRole('status');
+
+    await user.type(textarea, 'abcd');
+    expect(status).toHaveTextContent('');
+
+    await user.type(textarea, 'e');
+    expect(status).toHaveTextContent('20 characters left out of 25');
+  });
+}) as unknown as void;

--- a/components/textarea/Textarea.tsx
+++ b/components/textarea/Textarea.tsx
@@ -1,0 +1,370 @@
+import {
+  type ChangeEvent,
+  type TextareaHTMLAttributes,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+import { Button } from '../button';
+import { Tooltip } from '../tooltip';
+
+type CounterMessageFormatter =
+  string | ((value: number, maxLength: number) => string);
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /** Visible label text. When hideLabel is true this also serves as the aria-label
+   *  fallback if no explicit aria-label prop is provided. */
+  label?: string;
+  /** When true, the visible label element is hidden. The textarea is still labelled
+   *  accessibly via aria-label (prop) → label (prop) in that order of precedence. */
+  hideLabel?: boolean;
+  /** Marks the field as invalid: applies danger border colour and sets aria-invalid.
+   *  Independent of invalidFeedback — invalid styling can be shown without a message. */
+  invalid?: boolean;
+  /** Pre-translated error message rendered below the field. Requires invalid={true}
+   *  to be displayed. */
+  invalidFeedback?: string;
+  /** Optional supporting/helper text shown in the footer row when the field is not
+   *  in the invalid+feedback state. */
+  supportingText?: string;
+  /** Use disabled only when the field is unavailable for input.
+   *  Provide supportingText to explain why the control is disabled. */
+  disabled?: boolean;
+  /** Use readOnly when existing content must remain readable/copyable
+   *  but should not be editable. */
+  readOnly?: boolean;
+  /** When true the textarea renders a native resize handle (CSS resize: vertical).
+   *  Defaults to true. */
+  resizable?: boolean;
+  /** When true, shows a live character counter (current / maxLength) in the footer row.
+   *  Requires maxLength to be set. */
+  showCounter?: boolean;
+  /** Pre-translated label for the info tooltip shown beside the field label.
+   *  When provided, a `circle-info` icon button appears next to the label; hovering
+   *  or focusing it reveals a tooltip with this text. Only shown when the label is
+   *  visible (`hideLabel` is false or omitted). */
+  infoTooltipLabel?: string;
+  /** Accessible label for the visible counter text (for example,
+   *  "12 of 100 characters") as a translated string or formatter callback. */
+  counterAriaLabel?: CounterMessageFormatter;
+  /** Live-region announcement for remaining-character milestones (20, 10, 5, 0)
+   *  as a translated string or formatter callback. */
+  counterRemainingAnnouncement?: CounterMessageFormatter;
+  /** Live-region announcement for over-limit state as a translated string or
+   *  formatter callback. */
+  counterOverLimitAnnouncement?: CounterMessageFormatter;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    {
+      label,
+      hideLabel = false,
+      invalid,
+      invalidFeedback,
+      supportingText,
+      resizable = true,
+      showCounter = false,
+      infoTooltipLabel,
+      counterAriaLabel,
+      counterRemainingAnnouncement,
+      counterOverLimitAnnouncement,
+      className,
+      id: idProp,
+      required,
+      disabled,
+      readOnly,
+      rows = 3,
+      maxLength,
+      value,
+      defaultValue,
+      onChange,
+      onPointerDown,
+      onFocus,
+      onBlur,
+      'aria-label': ariaLabelProp,
+      'aria-describedby': ariaDescribedByProp,
+      ...textareaProps
+    }: TextareaProps,
+    ref,
+  ) => {
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
+    const isInvalid = !!invalid;
+    const hasVisibleLabel = !hideLabel;
+    const ariaLabel = hideLabel ? (ariaLabelProp ?? label) : undefined;
+
+    // Invalid feedback is tied to invalid state (and not disabled), independent
+    // of label visibility. Supporting text is replaced when feedback is shown.
+    const showInvalidFeedback = isInvalid && !disabled && !!invalidFeedback;
+    const footerText = showInvalidFeedback ? invalidFeedback : supportingText;
+    const feedbackId = footerText ? `${id}-feedback` : undefined;
+
+    // Character count is derived from controlled value length or defaultValue length at mount.
+    // Counter only renders when showCounter=true and maxLength is provided.
+    const showCounterEl = showCounter && maxLength != null;
+    const counterId = showCounterEl ? `${id}-counter` : undefined;
+    // Combine feedback and counter IDs so both are announced on field focus.
+    const describedBy =
+      [ariaDescribedByProp, feedbackId, counterId]
+        .filter((id): id is string => Boolean(id && id.trim().length > 0))
+        .join(' ') || undefined;
+
+    const [currentLength, setCurrentLength] = useState(
+      value != null
+        ? String(value).length
+        : defaultValue != null
+          ? String(defaultValue).length
+          : 0,
+    );
+
+    // Tracks the previous remaining count to detect milestone crossings.
+    const prevRemainingRef = useRef<number | null>(null);
+
+    // Tracks whether the current focus was initiated by a pointer (mouse/touch).
+    // Used to suppress the focus ring for pointer-initiated focus — the border
+    // change alone indicates the typing/selected state; the ring is reserved for
+    // keyboard navigation (WCAG 2.4.11 focus appearance is still satisfied because
+    // the focus ring is always shown for keyboard users).
+    const isPointerDownRef = useRef(false);
+    const [isPointerFocus, setIsPointerFocus] = useState(false);
+    // Announcement text for the visually-hidden live region. Updated only at
+    // thresholds so the counter does not announce on every keystroke.
+    const [announcement, setAnnouncement] = useState('');
+
+    const resolveCounterMessage = (
+      formatter: CounterMessageFormatter | undefined,
+      value: number,
+      max: number,
+    ) => {
+      if (!formatter) return undefined;
+      return typeof formatter === 'function'
+        ? formatter(value, max)
+        : formatter;
+    };
+
+    const updateAnnouncementForRemaining = useCallback(
+      (remaining: number, prev: number | null) => {
+        if (prev === null || maxLength == null) return;
+
+        // Announce only at meaningful milestones (ZeroHeight: throttle
+        // announcements — not on every keystroke).
+        if (remaining < 0) {
+          const overLimitText = resolveCounterMessage(
+            counterOverLimitAnnouncement,
+            Math.abs(remaining),
+            maxLength,
+          );
+          if (overLimitText) setAnnouncement(overLimitText);
+          return;
+        }
+
+        const milestones = [20, 10, 5, 0];
+        for (const threshold of milestones) {
+          if (prev > threshold && remaining <= threshold) {
+            const remainingText = resolveCounterMessage(
+              counterRemainingAnnouncement,
+              remaining,
+              maxLength,
+            );
+            if (remainingText) setAnnouncement(remainingText);
+            break;
+          }
+        }
+      },
+      [maxLength, counterOverLimitAnnouncement, counterRemainingAnnouncement],
+    );
+
+    useEffect(() => {
+      if (value != null) {
+        const nextLength = String(value).length;
+        const nextRemaining =
+          showCounterEl && maxLength != null ? maxLength - nextLength : null;
+        const prevRemaining = prevRemainingRef.current;
+
+        setCurrentLength(String(value).length);
+        // Keep prevRemainingRef in sync with controlled value updates so the
+        // milestone logic in handleChange uses the correct previous baseline.
+        if (nextRemaining != null) {
+          updateAnnouncementForRemaining(nextRemaining, prevRemaining);
+          prevRemainingRef.current = nextRemaining;
+        }
+      }
+    }, [value, maxLength, showCounterEl, updateAnnouncementForRemaining]);
+
+    const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+      if (showCounterEl) {
+        const newLength = event.target.value.length;
+        setCurrentLength(newLength);
+
+        if (maxLength != null) {
+          const remaining = maxLength - newLength;
+          const prev = prevRemainingRef.current;
+          prevRemainingRef.current = remaining;
+          updateAnnouncementForRemaining(remaining, prev);
+        }
+      }
+
+      onChange?.(event);
+    };
+
+    if (import.meta.env.DEV) {
+      if (hideLabel && !ariaLabelProp && !label) {
+        console.warn(
+          'Textarea: label prop or aria-label attribute is required for accessibility when hideLabel is true.',
+        );
+      }
+      if (!hideLabel && !label) {
+        console.warn(
+          'Textarea: label prop is required when hideLabel is false. An empty label creates an inaccessible form control.',
+        );
+      }
+      if (!hideLabel && label && ariaLabelProp) {
+        console.warn(
+          'Textarea: aria-label is ignored when a visible label is shown (hideLabel is false). The visible label is used as the accessible name instead.',
+        );
+      }
+      if (showCounter && maxLength == null) {
+        console.warn(
+          'Textarea: showCounter=true requires maxLength to be set so the counter can display a maximum.',
+        );
+      }
+      if (disabled && !supportingText?.trim()) {
+        console.warn(
+          'Textarea: disabled fields should include supportingText that explains why input is unavailable.',
+        );
+      }
+    }
+
+    const wrapperClasses = ['mds-textarea'];
+    if (className) wrapperClasses.push(className);
+
+    const textareaClasses = ['mds-textarea-field', 'form-control'];
+    if (isInvalid) textareaClasses.push('is-invalid');
+    if (!resizable) textareaClasses.push('mds-textarea-field--no-resize');
+    if (readOnly) textareaClasses.push('mds-textarea-field--readonly');
+    if (isPointerFocus)
+      textareaClasses.push('mds-textarea-field--pointer-focus');
+
+    return (
+      <div className={wrapperClasses.join(' ')}>
+        {hasVisibleLabel && (
+          <div className="mds-textarea-label-row">
+            <label className="mds-textarea-label form-label" htmlFor={id}>
+              <span className="mds-textarea-label-text">{label}</span>
+              {required && (
+                <span className="mds-textarea-required" aria-hidden="true">
+                  *
+                </span>
+              )}
+            </label>
+            {infoTooltipLabel && (
+              <Tooltip label={infoTooltipLabel} variant="light">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mds-textarea-info-button"
+                  aria-label={infoTooltipLabel}
+                  startIcon={
+                    <i className="fa-solid fa-circle-info" aria-hidden="true" />
+                  }
+                />
+              </Tooltip>
+            )}
+          </div>
+        )}
+        <div className="mds-textarea-field-wrapper">
+          <textarea
+            ref={ref}
+            id={id}
+            className={textareaClasses.join(' ')}
+            disabled={disabled}
+            readOnly={readOnly}
+            required={required}
+            rows={rows}
+            maxLength={maxLength}
+            value={value}
+            defaultValue={defaultValue}
+            aria-invalid={isInvalid ? true : undefined}
+            aria-label={ariaLabel}
+            aria-describedby={describedBy}
+            onChange={handleChange}
+            onPointerDown={(e) => {
+              isPointerDownRef.current = true;
+              onPointerDown?.(e);
+            }}
+            onFocus={(e) => {
+              if (isPointerDownRef.current) {
+                setIsPointerFocus(true);
+                isPointerDownRef.current = false;
+              }
+              onFocus?.(e);
+            }}
+            onBlur={(e) => {
+              setIsPointerFocus(false);
+              onBlur?.(e);
+            }}
+            {...textareaProps}
+          />
+          {isInvalid && !disabled && (
+            /* circle-exclamation icon: invalid state must not rely on colour alone (WCAG 1.4.1) */
+            <i
+              className="fa-solid fa-circle-exclamation mds-textarea-invalid-icon"
+              aria-hidden="true"
+            />
+          )}
+        </div>
+        {(footerText || showCounterEl) && (
+          <div className="mds-textarea-footer">
+            {feedbackId ? (
+              <span
+                id={feedbackId}
+                className={
+                  showInvalidFeedback
+                    ? 'mds-textarea-invalid-feedback'
+                    : 'mds-textarea-supporting-text'
+                }
+              >
+                {footerText}
+              </span>
+            ) : (
+              /* Spacer keeps the counter right-aligned when there is no footer text */
+              <span className="mds-textarea-footer-spacer" aria-hidden="true" />
+            )}
+            {showCounterEl && (
+              <>
+                <span
+                  id={counterId}
+                  className="mds-textarea-counter"
+                  dir="ltr"
+                  aria-label={resolveCounterMessage(
+                    counterAriaLabel,
+                    currentLength,
+                    maxLength,
+                  )}
+                >
+                  {currentLength} / {maxLength}
+                </span>
+                {/* Visually-hidden live region fires only at milestones so the
+                    counter does not announce on every keystroke. */}
+                <span
+                  className="mds-textarea-counter-announcement"
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  {announcement}
+                </span>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+Textarea.displayName = 'Textarea';

--- a/components/textarea/index.tsx
+++ b/components/textarea/index.tsx
@@ -1,0 +1,1 @@
+export * from './Textarea';

--- a/components/textarea/textarea.css
+++ b/components/textarea/textarea.css
@@ -1,0 +1,253 @@
+/* ==========================================================================
+   Textarea component
+   Builds on Bootstrap .form-control base; all visual overrides use --mds-*
+   tokens so they remain consistent with the Moodle Design System token set.
+   ========================================================================== */
+
+/* --- Wrapper ---------------------------------------------------------------- */
+
+.mds-textarea[class] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mds-spacing-xxs);
+
+  font-family: var(--mds-font-family-base);
+  font-size: var(--mds-font-size-paragraph-small);
+  font-weight: var(--mds-font-weight-regular);
+}
+
+/* --- Label ------------------------------------------------------------------ */
+
+/* Flex row that holds the <label> and the optional info icon-button side by side. */
+.mds-textarea[class] .mds-textarea-label-row {
+  display: flex;
+  align-items: center;
+  min-height: 16px; /* hardcoded as per Figma Fixed spec */
+  gap: var(--mds-spacing-xxs);
+}
+
+.mds-textarea[class] .mds-textarea-label {
+  /* Reset Bootstrap's form-label bottom-margin — gap on the wrapper handles spacing. */
+  margin-bottom: 0;
+
+  display: flex;
+  align-items: center;
+  gap: var(--mds-spacing-xxs);
+
+  font-size: var(--mds-font-size-paragraph-small);
+  font-weight: var(--mds-font-weight-medium);
+  line-height: var(--mds-line-height-paragraph-xs);
+  color: var(--mds-text-subtle);
+}
+
+.mds-textarea[class] .mds-textarea-required {
+  color: var(--mds-text-danger);
+  font-size: var(--mds-font-size-paragraph-small);
+  font-weight: var(--mds-font-weight-medium);
+}
+
+/* Info icon-button beside the label — reuses Button ghost sm for the hit area,
+   focus ring, and hover/active fills. Button icon-only sm forces icons.xxs;
+   override restores the spec-correct icons.xs size. Padding is zeroed so the
+   button stays 16px tall and aligns flush with the label row height. */
+.mds-textarea[class] .mds-textarea-info-button.mds-btn {
+  padding: 0;
+}
+
+.mds-textarea[class] .mds-textarea-info-button.mds-btn i {
+  font-size: var(--mds-icons-xs);
+  inline-size: var(--mds-icons-xs);
+  block-size: var(--mds-icons-xs);
+}
+
+/* --- Textarea field --------------------------------------------------------- */
+
+/* Wrapper provides position context for the absolutely-placed invalid icon. */
+.mds-textarea[class] .mds-textarea-field-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+/* Use [class] to outrank Bootstrap's .form-control specificity */
+.mds-textarea[class] .mds-textarea-field[class] {
+  display: block;
+  width: 100%;
+  padding: var(--mds-spacing-xs) var(--mds-spacing-sm);
+  resize: vertical;
+
+  font-family: var(--mds-font-family-base);
+  font-size: var(--mds-font-size-paragraph-default);
+  font-weight: var(--mds-font-weight-regular);
+  line-height: var(--mds-line-height-paragraph-default);
+  letter-spacing: var(--mds-letter-spacing-default);
+  color: var(--mds-text-default);
+
+  /* Default container fill is transparent (design spec: hover transitions to
+     bg.surface.default to signal interactivity without changing the border). */
+  background-color: transparent;
+  border: var(--mds-stroke-weight-sm) solid
+    var(--mds-border-interactive-secondary-default);
+  border-radius: var(--mds-border-radius-sm);
+
+  /* Animate default -> hover fill; border state changes remain immediate. */
+  transition: background-color 150ms ease;
+}
+
+.mds-textarea[class] .mds-textarea-field--no-resize[class] {
+  resize: none;
+}
+
+/* Placeholder text */
+.mds-textarea[class] .mds-textarea-field[class]::placeholder {
+  color: var(--mds-text-muted);
+  opacity: 1; /* Firefox reduces opacity by default */
+}
+
+/* Hover — fill transitions from transparent to surface; border stays unchanged
+   (design spec: hover is a subtle interactive cue, not a state indicator). */
+.mds-textarea[class]
+  .mds-textarea-field[class]:hover:not(:disabled):not(:focus) {
+  background-color: var(--mds-bg-surface-default);
+}
+
+/* Active / pressed — primary accent border marks the field being edited. */
+.mds-textarea[class] .mds-textarea-field[class]:active:not(:disabled) {
+  background-color: var(--mds-bg-surface-default);
+  border-color: var(--mds-border-interactive-primary-default);
+}
+
+/* Focus — reset Bootstrap's box-shadow; apply MDS focus ring on focus-visible only */
+.mds-textarea[class] .mds-textarea-field[class]:focus {
+  background-color: var(--mds-bg-surface-default);
+  border-color: var(--mds-border-interactive-secondary-default);
+  box-shadow: none;
+  outline: none;
+}
+
+.mds-textarea[class] .mds-textarea-field[class]:focus-visible {
+  outline: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
+  outline-offset: 0;
+  border-color: var(--mds-focus-default);
+}
+
+/* Pointer-initiated focus (mouse/touch): suppress the ring — the primary border
+   signals the selected/typing state. The ring is reserved for keyboard navigation. */
+.mds-textarea[class] .mds-textarea-field--pointer-focus[class]:focus-visible {
+  outline: none;
+  border-color: var(--mds-border-interactive-primary-default);
+}
+
+/* Invalid */
+.mds-textarea[class] .mds-textarea-field.is-invalid[class] {
+  border-color: var(--mds-border-interactive-danger-default);
+  /* Extra right padding prevents entered text from sliding under the
+     circle-exclamation icon that is absolutely positioned inside the wrapper. */
+  padding-inline-end: calc(
+    var(--mds-icons-xs) + var(--mds-spacing-sm) + var(--mds-spacing-xxs)
+  );
+  /* Suppress Bootstrap's background validation icon on textareas — MDS renders
+     the circle-exclamation icon as a positioned element instead. */
+  background-image: none;
+}
+
+/* Absolutely-positioned circle-exclamation icon within .mds-textarea-field-wrapper. */
+.mds-textarea[class] .mds-textarea-invalid-icon {
+  position: absolute;
+  top: var(--mds-spacing-xs);
+  inset-inline-end: var(--mds-spacing-sm);
+  color: var(--mds-text-danger);
+  font-size: var(--mds-icons-xs);
+  line-height: 1;
+  pointer-events: none;
+}
+
+.mds-textarea[class] .mds-textarea-field.is-invalid[class]:focus-visible {
+  outline-color: var(--mds-focus-danger);
+  border-color: var(--mds-focus-danger);
+}
+
+/* Pointer-initiated focus on an invalid field: keep the strong danger border
+   (no ring) rather than the pale focus-danger tone reserved for keyboard focus. */
+.mds-textarea[class]
+  .mds-textarea-field--pointer-focus.is-invalid[class]:focus-visible {
+  outline: none;
+  border-color: var(--mds-border-interactive-danger-default);
+}
+
+/* Disabled */
+.mds-textarea[class] .mds-textarea-field[class]:disabled {
+  background-color: var(--mds-bg-surface-strong);
+  border-color: var(--mds-border-interactive-secondary-default);
+  color: var(--mds-text-muted);
+  resize: none;
+  cursor: not-allowed;
+}
+
+/* Read-only */
+.mds-textarea[class] .mds-textarea-field--readonly[class] {
+  background-color: var(--mds-bg-surface-default);
+  border-color: var(--mds-border-interactive-secondary-default);
+  color: var(--mds-text-muted);
+}
+
+/* --- Footer row (supporting text + counter) --------------------------------- */
+
+.mds-textarea[class] .mds-textarea-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--mds-spacing-xs);
+
+  font-size: var(--mds-font-size-paragraph-small);
+  font-weight: var(--mds-font-weight-regular);
+  line-height: var(--mds-line-height-paragraph-small);
+  letter-spacing: var(--mds-letter-spacing-default);
+}
+
+.mds-textarea[class] .mds-textarea-footer-spacer {
+  flex: 1 0 0;
+}
+
+.mds-textarea[class] .mds-textarea-supporting-text {
+  flex: 1 0 0;
+  color: var(--mds-text-muted);
+}
+
+/* Supporting text is danger-coloured when invalid (not disabled), matching the border and label. */
+.mds-textarea[class]:has(.mds-textarea-field.is-invalid:not(:disabled))
+  .mds-textarea-supporting-text {
+  color: var(--mds-text-danger);
+}
+
+/* Not using Bootstrap's invalid-feedback class: its display: none + block
+   toggle relies on a sibling selector off .is-invalid, but .is-invalid sits
+   on the textarea inside .mds-textarea-field-wrapper while this element is a
+   sibling of that wrapper, so the selector never matches. We control
+   visibility ourselves by conditionally rendering the element instead. */
+.mds-textarea[class] .mds-textarea-invalid-feedback {
+  display: block;
+  flex: 1 0 0;
+  margin-top: 0;
+  font-size: var(--mds-font-size-paragraph-small);
+  color: var(--mds-text-danger);
+}
+
+.mds-textarea[class] .mds-textarea-counter {
+  flex-shrink: 0;
+  color: var(--mds-text-subtle);
+  text-align: end;
+  unicode-bidi: isolate;
+  /* Reserve enough space for "NNN / NNN" to prevent layout shift. */
+  min-width: 4rem;
+}
+
+/* Visually hides the milestone live region while keeping it accessible to AT.
+   Uses clip-path to avoid the position:absolute approach which would require
+   a positioned ancestor on .mds-textarea. */
+.mds-textarea[class] .mds-textarea-counter-announcement {
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/scripts/generate-component-index.ts
+++ b/scripts/generate-component-index.ts
@@ -144,6 +144,8 @@ const PURPOSES: Record<string, string> = {
   radio:
     'Single-select options in a compact list (native radio input, label only). No group wrapper is provided — see the Group story for consumer-supplied layout.',
   switch: 'Binary toggle control for on/off settings.',
+  textarea:
+    'Multi-line text input with label, placeholder, supporting text, character counter, and validation feedback.',
   tooltip: 'Contextual label anchored to a trigger element.',
 };
 


### PR DESCRIPTION
## Description

Adds a new `Textarea` component with accessible labeling, validation feedback, supporting text, optional character counter, optional info tooltip, and Storybook plus unit test coverage for core behaviors.

### Key implementation decisions

- Built on native `<textarea>` semantics plus Bootstrap’s `form-control` baseline, then layered MDS styling via `mds-*` classes and tokenized CSS variables.
- Kept label visibility and accessible naming decoupled: when visual label is hidden, the control is still named through `aria-label` fallback logic.
- Chose conditional invalid feedback rendering (instead of always-rendered hidden message) to keep spoken output concise and avoid unnecessary `aria-describedby` noise.
- Added invalid-state icon so error state is not communicated by color alone.
- Counter is opt-in and only active with `maxLength`; implemented milestone-based live announcements to reduce screen-reader verbosity.
- Counter and supporting/feedback content share a single footer row to preserve layout consistency across states.
- Included RTL coverage in stories and forced LTR numeric counter direction for predictable number formatting in mixed-direction UIs.
- Reused existing `Button` + `Tooltip` for the info affordance to avoid introducing new interaction primitives.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-641

## Screenshots/Previews
<img width="1060" height="627" alt="Screenshot 2026-08-21 at 3 22 56 pm" src="https://github.com/user-attachments/assets/b74227df-2ed2-4fe4-86e1-664c46930a83" />

## Author checklist

### File structure and exports

- [x] All 5 required files present: `ComponentName.tsx`, `component-name.css`, `ComponentName.test.tsx`, `ComponentName.stories.tsx`, `index.tsx`
- [x] `ComponentName.figma.tsx` Code Connect file created and published
- [x] Named and type exports added to `components/index.tsx`
- [x] Component stylesheet imported in `components/index.css`

### TypeScript and props

- [x] Props interface extends the correct React HTML element interface (e.g. `ButtonHTMLAttributes<HTMLButtonElement>`)
- [x] JSDoc comment on each prop
- [ ] Constrained props use `allowedValues` runtime validation with a graceful fallback to a documented default
  - Reason: This Textarea API does not introduce constrained string-union props that need runtime narrowing. Existing defaults are handled directly (for example, booleans and rows), so the specific allowedValues pattern is not applied.
- [x] `...props` spread last on the host element

### Internationalisation

- [x] All user-facing strings accepted as props — no hardcoded text in JSX
  - Reason: Some user-facing text is currently hardcoded in component logic, including development warnings and counter/live-region announcement phrases (for example, “of”, “characters remaining”, “over the character limit”), so not all visible/announced strings are externally provided as props.
  - Cleared: New props added to supply strings.
- [x] CSS uses logical properties (`margin-inline-*`, `padding-inline-*`, `inset-inline-*`) for any directional layout
- [x] RTL story added if the component has directional layout

### CSS and tokens

- [x] All CSS values use `var(--mds-*)` tokens — no hardcoded colours, spacing, or typography
- [x] Where a matching token exists, `var(--mds-*)` is used without fallback literals (for example, `var(--mds-spacing-xs)`, not `var(--mds-spacing-xs, 0.5rem)`)

### Tests and stories

- [x] Unit tests cover: `mds-*` class on root, correct classes per variant/size, invalid prop fallback, prop forwarding, disabled state, and label rendering
- [x] Storybook stories cover all documented variants, sizes, and states
- [x] Accessibility tested — Axe WCAG AA scan runs automatically via CI on all stories tagged `test`

### Breaking changes

- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump

### AI context

- [x] Instruction files updated if this component introduces new patterns or anti-patterns

## Cross-system parity

- [x] Component name, prop names, and variant names are consistent across code, Storybook, Figma, and Zeroheight

## Additional Notes
N/A