### PR TITLE
fix(Badge, Link): Increase specificity on the class selectors

### DIFF
--- a/components/badge/badge.css
+++ b/components/badge/badge.css
@@ -1,4 +1,4 @@
-.mds-badge {
+.mds-badge[class] {
   display: inline-flex;
   align-items: center;
   gap: 0;
@@ -14,13 +14,13 @@
   vertical-align: baseline;
 }
 
-.mds-badge--has-icon {
+.mds-badge[class].mds-badge--has-icon {
   gap: var(--mds-spacing-xxs);
 }
 
 /* Normalize icon dimensions to match the badge icon token across <i> and <svg> usage. */
-.mds-badge > i,
-.mds-badge > svg {
+.mds-badge[class] > i,
+.mds-badge[class] > svg {
   width: var(--mds-icons-xxs);
   height: var(--mds-icons-xxs);
   font-size: var(--mds-icons-xxs);
@@ -28,7 +28,7 @@
 }
 
 /* Pill shape overrides the default rounded corners */
-.mds-badge--pill {
+.mds-badge[class].mds-badge--pill {
   border-radius: var(--mds-border-radius-pill);
 }
 
@@ -38,77 +38,77 @@
  * Subtle contrast (.mds-badge--subtle): light tinted background, dark feedback text, visible border.
  */
 
-.mds-badge--subtle {
+.mds-badge[class].mds-badge--subtle {
   border: var(--mds-stroke-weight-sm) solid transparent;
 }
 
 /* --- Primary --- */
-.mds-badge--primary {
+.mds-badge[class].mds-badge--primary {
   background-color: var(--mds-bg-feedback-primary-default);
   color: var(--mds-text-inverse);
 }
 
-.mds-badge--primary.mds-badge--subtle {
+.mds-badge[class].mds-badge--primary.mds-badge--subtle {
   background-color: var(--mds-bg-feedback-primary-subtle);
   color: var(--mds-text-feedback-primary);
   border-color: var(--mds-border-feedback-primary);
 }
 
 /* --- Secondary --- */
-.mds-badge--secondary {
+.mds-badge[class].mds-badge--secondary {
   background-color: var(--mds-bg-feedback-secondary-default);
   color: var(--mds-text-feedback-secondary);
 }
 
-.mds-badge--secondary.mds-badge--subtle {
+.mds-badge[class].mds-badge--secondary.mds-badge--subtle {
   background-color: var(--mds-bg-feedback-secondary-subtle);
   color: var(--mds-text-feedback-secondary);
   border-color: var(--mds-border-feedback-secondary);
 }
 
 /* --- Success --- */
-.mds-badge--success {
+.mds-badge[class].mds-badge--success {
   background-color: var(--mds-bg-feedback-success-default);
   color: var(--mds-text-inverse);
 }
 
-.mds-badge--success.mds-badge--subtle {
+.mds-badge[class].mds-badge--success.mds-badge--subtle {
   background-color: var(--mds-bg-feedback-success-subtle);
   color: var(--mds-text-feedback-success);
   border-color: var(--mds-border-feedback-success);
 }
 
 /* --- Danger --- */
-.mds-badge--danger {
+.mds-badge[class].mds-badge--danger {
   background-color: var(--mds-bg-feedback-danger-default);
   color: var(--mds-text-inverse);
 }
 
-.mds-badge--danger.mds-badge--subtle {
+.mds-badge[class].mds-badge--danger.mds-badge--subtle {
   background-color: var(--mds-bg-feedback-danger-subtle);
   color: var(--mds-text-feedback-danger);
   border-color: var(--mds-border-feedback-danger);
 }
 
 /* --- Warning --- */
-.mds-badge--warning {
+.mds-badge[class].mds-badge--warning {
   background-color: var(--mds-bg-feedback-warning-default);
   color: var(--mds-text-feedback-warning);
 }
 
-.mds-badge--warning.mds-badge--subtle {
+.mds-badge[class].mds-badge--warning.mds-badge--subtle {
   background-color: var(--mds-bg-feedback-warning-subtle);
   color: var(--mds-text-feedback-warning);
   border-color: var(--mds-border-feedback-warning);
 }
 
 /* --- Info --- */
-.mds-badge--info {
+.mds-badge[class].mds-badge--info {
   background-color: var(--mds-bg-feedback-info-default);
   color: var(--mds-text-inverse);
 }
 
-.mds-badge--info.mds-badge--subtle {
+.mds-badge[class].mds-badge--info.mds-badge--subtle {
   background-color: var(--mds-bg-feedback-info-subtle);
   color: var(--mds-text-feedback-info);
   border-color: var(--mds-border-feedback-info);

--- a/components/link/link.css
+++ b/components/link/link.css
@@ -1,4 +1,4 @@
-.mds-link {
+.mds-link[class] {
   display: inline-flex;
   align-items: center;
   gap: var(--mds-spacing-xs);
@@ -14,18 +14,18 @@
   cursor: pointer;
 }
 
-.mds-link:hover:not(:focus-visible) {
+.mds-link[class]:hover:not(:focus-visible) {
   color: var(--mds-text-link-primary-hover);
 }
 
-.mds-link:active {
+.mds-link[class]:active {
   color: var(--mds-text-link-primary-hover);
 }
 
 /* Underline on hover applies only to the label text, not the icon.
    Pressed state has no underline (Figma). Thickness and position use
    from-font so the underline follows the font's own metrics. */
-.mds-link:hover:not(:focus-visible) .mds-link__label {
+.mds-link[class]:hover:not(:focus-visible) .mds-link__label {
   text-decoration: underline;
   text-decoration-thickness: from-font;
   text-underline-position: from-font;
@@ -33,32 +33,36 @@
 
 /* Slide icon toward the label on hover using transform so the link node width
    stays constant (gap remains --mds-spacing-xs; only the icon moves visually). */
-.mds-link:hover:not(:focus-visible) .mds-link__icon:first-child {
+.mds-link[class]:hover:not(:focus-visible) .mds-link__icon:first-child {
   transform: translateX(var(--mds-spacing-xxs));
 }
 
-.mds-link:hover:not(:focus-visible) .mds-link__icon:last-child {
+.mds-link[class]:hover:not(:focus-visible) .mds-link__icon:last-child {
   transform: translateX(calc(-1 * var(--mds-spacing-xxs)));
 }
 
-[dir='rtl'] .mds-link:hover:not(:focus-visible) .mds-link__icon:first-child {
+[dir='rtl']
+  .mds-link[class]:hover:not(:focus-visible)
+  .mds-link__icon:first-child {
   transform: translateX(calc(-1 * var(--mds-spacing-xxs)));
 }
 
-[dir='rtl'] .mds-link:hover:not(:focus-visible) .mds-link__icon:last-child {
+[dir='rtl']
+  .mds-link[class]:hover:not(:focus-visible)
+  .mds-link__icon:last-child {
   transform: translateX(var(--mds-spacing-xxs));
 }
 
 /* Reset icon position on press */
-.mds-link:active .mds-link__icon {
+.mds-link[class]:active .mds-link__icon {
   transform: none;
 }
 
-.mds-link:focus {
+.mds-link[class]:focus {
   outline: none;
 }
 
-.mds-link:focus-visible {
+.mds-link[class]:focus-visible {
   /* Bottom-only focus underline matching Figma: 2px border-bottom, 1px gap below content */
   outline: none;
   border-radius: 0;
@@ -66,43 +70,43 @@
   border-bottom: var(--mds-stroke-weight-md) solid var(--mds-focus-default);
 }
 
-.mds-link.mds-link--secondary {
+.mds-link[class].mds-link--secondary {
   color: var(--mds-text-subtle);
 }
 
-.mds-link.mds-link--secondary:hover:not(:focus-visible),
-.mds-link.mds-link--secondary:active {
+.mds-link[class].mds-link--secondary:hover:not(:focus-visible),
+.mds-link[class].mds-link--secondary:active {
   color: var(--mds-text-default);
 }
 
-.mds-link.mds-link--disabled,
-.mds-link.mds-link--disabled:hover,
-.mds-link.mds-link--disabled:active {
+.mds-link[class].mds-link--disabled,
+.mds-link[class].mds-link--disabled:hover,
+.mds-link[class].mds-link--disabled:active {
   color: var(--mds-text-link-primary-disabled);
   pointer-events: none;
 }
 
-.mds-link.mds-link--disabled .mds-link__icon,
-.mds-link.mds-link--disabled:hover .mds-link__icon,
-.mds-link.mds-link--disabled:active .mds-link__icon {
+.mds-link[class].mds-link--disabled .mds-link__icon,
+.mds-link[class].mds-link--disabled:hover .mds-link__icon,
+.mds-link[class].mds-link--disabled:active .mds-link__icon {
   transform: none;
 }
 
-.mds-link.mds-link--disabled .mds-link__label,
-.mds-link.mds-link--disabled:hover .mds-link__label,
-.mds-link.mds-link--disabled:active .mds-link__label {
+.mds-link[class].mds-link--disabled .mds-link__label,
+.mds-link[class].mds-link--disabled:hover .mds-link__label,
+.mds-link[class].mds-link--disabled:active .mds-link__label {
   text-decoration: none;
 }
 
-.mds-link.mds-link--secondary.mds-link--disabled,
-.mds-link.mds-link--secondary.mds-link--disabled:hover,
-.mds-link.mds-link--secondary.mds-link--disabled:active {
+.mds-link[class].mds-link--secondary.mds-link--disabled,
+.mds-link[class].mds-link--secondary.mds-link--disabled:hover,
+.mds-link[class].mds-link--secondary.mds-link--disabled:active {
   color: var(--mds-text-muted);
 }
 
-.mds-link__icon,
-.mds-link__icon i,
-.mds-link__icon svg {
+.mds-link[class] .mds-link__icon,
+.mds-link[class] .mds-link__icon i,
+.mds-link[class] .mds-link__icon svg {
   inline-size: var(--mds-icons-xs);
   block-size: var(--mds-icons-xs);
   font-size: var(--mds-icons-xs);
@@ -110,13 +114,13 @@
   flex-shrink: 0;
 }
 
-.mds-link__icon {
+.mds-link[class] .mds-link__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   transition: transform 150ms ease;
 }
 
-.mds-link__label {
+.mds-link[class] .mds-link__label {
   text-align: start;
 }


### PR DESCRIPTION
## Description

Adds `[class]` attribute selector to all `mds-badge` and `mds-link` CSS selectors to increase specificity and prevent Bootstrap's own component classes and utility classes from overriding design system styles.

**Root cause:** Single-class selectors (e.g. `.mds-badge`) have specificity `(0,1,0)`, identical to Bootstrap classes. When Bootstrap classes are present on the same element — either from Bootstrap's own component stylesheet or consumer-applied utilities — they compete at equal specificity and the last declaration in the cascade wins, producing inconsistent visual output.

**Specifically fixing against:**

- **Badge** — Bootstrap 5 ships its own `.badge` class with `background-color`, `color`, `padding`, and `border-radius` declarations at `(0,1,0)`. When a consumer renders `<span class="mds-badge badge">`, Bootstrap's `.badge` rules silently override `.mds-badge--primary` / `.mds-badge--subtle` / `.mds-badge--pill` variant styles. Bootstrap utility classes such as `.text-bg-primary`, `.rounded-pill`, `.text-white`, and `.gap-*` present the same problem.
- **Link** — Bootstrap's `.link-primary`, `.link-secondary`, `.link-*` colour utilities, and `.text-decoration-*` utilities are all `(0,1,0)` and override `.mds-link`, `.mds-link--secondary`, and the hover/active/focus-visible colour rules. Bootstrap's `a` element base styles are lower specificity, but any `.link-*` utility applied by a consumer wins against the un-suffixed `.mds-link` selector.

**Fix:** Appending `[class]` to every component root selector raises specificity to `(0,1,1)` — one attribute selector higher — without changing the rendered HTML, adding wrapper elements, or using `!important`. All modifier selectors (`.mds-badge--primary`, `.mds-link--secondary`, etc.) and child-element selectors (`.mds-link__icon`, `.mds-link__label`) are updated consistently.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-606

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews
Tested in the LMS PVT and the fix can be seen applied correctly
<img width="130" height="74" alt="Screenshot 2026-08-21 at 5 07 28 pm" src="https://github.com/user-attachments/assets/6330f363-9355-43f0-afca-bbbe2fb7a40b" />
<img width="103" height="83" alt="Screenshot 2026-08-21 at 5 08 00 pm" src="https://github.com/user-attachments/assets/a355d31c-70ca-40ed-b9c3-c732d2645787" />

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

The `[class]` specificity pattern is the established approach for this codebase. Both `Badge` and `Link` were affected due to the same root cause. All modifier and child-element selectors in both files have been updated uniformly to maintain consistent cascade ordering across all variants and states.