### PR TITLE
refactor(FieldInfoButton): New reusable internal FieldInfoButton component

### DIFF
--- a/components/_internal/FieldInfoButton.tsx
+++ b/components/_internal/FieldInfoButton.tsx
@@ -1,0 +1,20 @@
+import { Button } from '../button';
+import { Tooltip } from '../tooltip';
+
+interface FieldInfoButtonProps {
+  label: string;
+}
+
+export function FieldInfoButton({ label }: FieldInfoButtonProps) {
+  return (
+    <Tooltip label={label} variant="light">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="mds-field-info-button"
+        aria-label={label}
+        startIcon={<i className="fa-solid fa-circle-info" aria-hidden="true" />}
+      />
+    </Tooltip>
+  );
+}

--- a/components/_internal/field-info-button.css
+++ b/components/_internal/field-info-button.css
@@ -1,0 +1,10 @@
+.mds-btn.btn.mds-btn--icon-only.mds-btn--size-sm.mds-field-info-button {
+  padding: 0;
+}
+
+.mds-btn.btn.mds-btn--icon-only.mds-btn--size-sm.mds-field-info-button i,
+.mds-btn.btn.mds-btn--icon-only.mds-btn--size-sm.mds-field-info-button svg {
+  inline-size: var(--mds-icons-xs);
+  block-size: var(--mds-icons-xs);
+  font-size: var(--mds-icons-xs);
+}

--- a/components/index.css
+++ b/components/index.css
@@ -1,3 +1,4 @@
+@import './_internal/field-info-button.css';
 @import './activity-icon/activity-icon.css';
 @import './alert/alert.css';
 @import './avatar/avatar.css';

--- a/components/textarea/Textarea.test.tsx
+++ b/components/textarea/Textarea.test.tsx
@@ -352,7 +352,7 @@ describe('Textarea: Unit Test', () => {
     render(<Textarea label="Field" infoTooltipLabel="More about this field" />);
     expect(
       screen.getByRole('button', { name: 'More about this field' }),
-    ).toBeInTheDocument();
+    ).toHaveClass('mds-field-info-button');
   });
 
   it('does not render the info button when hideLabel is true', () => {

--- a/components/textarea/Textarea.tsx
+++ b/components/textarea/Textarea.tsx
@@ -8,8 +8,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Button } from '../button';
-import { Tooltip } from '../tooltip';
+import { FieldInfoButton } from '../_internal/FieldInfoButton';
 
 type CounterMessageFormatter =
   string | ((value: number, maxLength: number) => string);
@@ -261,19 +260,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                 </span>
               )}
             </label>
-            {infoTooltipLabel && (
-              <Tooltip label={infoTooltipLabel} variant="light">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="mds-textarea-info-button"
-                  aria-label={infoTooltipLabel}
-                  startIcon={
-                    <i className="fa-solid fa-circle-info" aria-hidden="true" />
-                  }
-                />
-              </Tooltip>
-            )}
+            {infoTooltipLabel && <FieldInfoButton label={infoTooltipLabel} />}
           </div>
         )}
         <div className="mds-textarea-field-wrapper">

--- a/components/textarea/textarea.css
+++ b/components/textarea/textarea.css
@@ -46,20 +46,6 @@
   font-weight: var(--mds-font-weight-medium);
 }
 
-/* Info icon-button beside the label — reuses Button ghost sm for the hit area,
-   focus ring, and hover/active fills. Button icon-only sm forces icons.xxs;
-   override restores the spec-correct icons.xs size. Padding is zeroed so the
-   button stays 16px tall and aligns flush with the label row height. */
-.mds-textarea[class] .mds-textarea-info-button.mds-btn {
-  padding: 0;
-}
-
-.mds-textarea[class] .mds-textarea-info-button.mds-btn i {
-  font-size: var(--mds-icons-xs);
-  inline-size: var(--mds-icons-xs);
-  block-size: var(--mds-icons-xs);
-}
-
 /* --- Textarea field --------------------------------------------------------- */
 
 /* Wrapper provides position context for the absolutely-placed invalid icon. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ const dirname = import.meta.dirname;
 const componentEntries = Object.fromEntries(
   fs
     .readdirSync(path.join(dirname, 'components'), { withFileTypes: true })
-    .filter((d) => d.isDirectory())
+    .filter((d) => d.isDirectory() && !d.name.startsWith('_'))
     .map((d) => [
       `components/${d.name}/index`,
       `./components/${d.name}/index.tsx`,
@@ -25,6 +25,7 @@ const componentEntries = Object.fromEntries(
 
 interface ComponentCssAsset {
   componentName: string;
+  isInternal: boolean;
   source: string;
 }
 
@@ -102,9 +103,13 @@ function getComponentCssAssets(): ComponentCssAsset[] {
     const componentName = path.posix
       .normalize(path.dirname(relativeImportPath))
       .replace(/^\.\//, '');
+    const isInternal = componentName
+      .split('/')
+      .some((segment) => segment.startsWith('_'));
 
     assets.push({
       componentName,
+      isInternal,
       source: inlineCssImageUrls(
         fs.readFileSync(absoluteImportPath, 'utf8').trim(),
         path.dirname(absoluteImportPath),
@@ -116,11 +121,14 @@ function getComponentCssAssets(): ComponentCssAsset[] {
 }
 
 function buildComponentsCssManifest(assets: ComponentCssAsset[]): string {
-  const imports = assets.map(
-    (asset) => `@import './${asset.componentName}/index.css';`,
-  );
+  const imports = assets
+    .filter((asset) => !asset.isInternal)
+    .map((asset) => `@import './${asset.componentName}/index.css';`);
+  const internalSources = assets
+    .filter((asset) => asset.isInternal)
+    .map((asset) => asset.source);
 
-  return `${imports.join('\n')}\n`;
+  return `${[...imports, ...internalSources].join('\n')}\n`;
 }
 
 function buildComponentsLegacyScssManifest(
@@ -154,7 +162,7 @@ function emitComponentAssets(ctx: PluginContext): void {
   });
 
   // Per-component CSS files
-  for (const componentAsset of assets) {
+  for (const componentAsset of assets.filter((asset) => !asset.isInternal)) {
     ctx.emitFile({
       type: 'asset',
       fileName: `components/${componentAsset.componentName}/index.css`,


### PR DESCRIPTION
## Description

Adds a reusable internal `FieldInfoButton` helper for the field-label info tooltip pattern used by form controls.

This extracts the repeated Tooltip + ghost icon-only Button setup into `components/_internal/FieldInfoButton.tsx`, with colocated internal CSS for the compact field info button styling. `Textarea` now uses the shared helper, and the `_internal` folder is excluded from public component entrypoint and per-component CSS asset generation so it remains an implementation detail.

This prepares the same pattern to be reused by upcoming form controls such as Checkbox without adding a public component API.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-657

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

No visual changes intended.

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

Security impact: no security-sensitive logic changed. This is a UI composition and build-entry filtering refactor only.

Breaking change assessment: no public props, exports, or tokens were removed or renamed. The new `_internal` helper is intentionally not exported as a public component.