### PR TITLE
chore(Choicebox): Remove beta tag from WithIcon story

### DIFF
--- a/components/choicebox/Choicebox.stories.tsx
+++ b/components/choicebox/Choicebox.stories.tsx
@@ -192,7 +192,7 @@ export const WithIcon: Story = {
     label: 'Label text',
     icon: <i className="fa-solid fa-star" />,
   },
-  tags: ['autodocs', 'test', 'beta'],
+  tags: ['autodocs', 'test'],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByRole('radio');


### PR DESCRIPTION
## Description

Removes the `beta` Storybook tag from the Choicebox `WithIcon` story.

This updates the story metadata now that the icon variant should no longer be marked as beta. No runtime component behavior, public API, styling, or visual output is changed.

## Related Jira or GitHub Issue

<!-- Link to related issues or tickets (e.g., https://moodle.atlassian.net/browse/MDS-191) -->

## Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

Storybook metadata maintenance.

## Screenshots/Previews

No screenshots required. This only changes Storybook story tags and does not affect the rendered UI.

## Checklist

- [ ] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [ ] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [ ] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

Accessibility impact: none. The story remains tagged for Storybook tests.

Security impact: none. This is metadata-only.

Breaking change assessment: no public props, exports, tokens, or runtime behavior changed.