### PR TITLE
fix(Textarea): Suppress invalid state when disabled or readOnly

### DIFF
--- a/components/textarea/Textarea.test.tsx
+++ b/components/textarea/Textarea.test.tsx
@@ -539,6 +539,43 @@ describe('Textarea: Unit Test', () => {
     expect(screen.queryByText('Error message')).not.toBeInTheDocument();
   });
 
+  it('does not apply invalid styling when invalid is true and disabled', () => {
+    const { container } = render(<Textarea label="Field" disabled invalid />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).not.toHaveClass('is-invalid');
+    expect(textarea).not.toHaveAttribute('aria-invalid');
+    expect(
+      container.querySelector('.mds-textarea-invalid-icon'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not apply invalid styling when invalid is true and readOnly', () => {
+    const { container } = render(<Textarea label="Field" readOnly invalid />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).not.toHaveClass('is-invalid');
+    expect(textarea).not.toHaveAttribute('aria-invalid');
+    expect(
+      container.querySelector('.mds-textarea-invalid-icon'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render invalidFeedback when invalid is true and readOnly', () => {
+    render(
+      <Textarea
+        label="Field"
+        readOnly
+        invalid
+        invalidFeedback="Error message"
+        supportingText="Guidance text"
+      />,
+    );
+
+    expect(screen.getByText('Guidance text')).toBeInTheDocument();
+    expect(screen.queryByText('Error message')).not.toBeInTheDocument();
+  });
+
   it('shows controlled values above maxLength in the counter display', () => {
     const { rerender } = render(
       <Textarea

--- a/components/textarea/Textarea.tsx
+++ b/components/textarea/Textarea.tsx
@@ -21,7 +21,8 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
    *  accessibly via aria-label (prop) → label (prop) in that order of precedence. */
   hideLabel?: boolean;
   /** Marks the field as invalid: applies danger border colour and sets aria-invalid.
-   *  Independent of invalidFeedback — invalid styling can be shown without a message. */
+   *  Independent of invalidFeedback — invalid styling can be shown without a message.
+   *  Has no effect when disabled or readOnly — those states don't carry an invalid state. */
   invalid?: boolean;
   /** Pre-translated error message rendered below the field. Requires invalid={true}
    *  to be displayed. */
@@ -92,13 +93,15 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ) => {
     const generatedId = useId();
     const id = idProp ?? generatedId;
-    const isInvalid = !!invalid;
+    // Disabled and read-only fields don't carry an invalid state — invalid is only
+    // ever a modifier on top of default/hover/active/focus per the design spec.
+    const isInvalid = !!invalid && !disabled && !readOnly;
     const hasVisibleLabel = !hideLabel;
     const ariaLabel = hideLabel ? (ariaLabelProp ?? label) : undefined;
 
-    // Invalid feedback is tied to invalid state (and not disabled), independent
-    // of label visibility. Supporting text is replaced when feedback is shown.
-    const showInvalidFeedback = isInvalid && !disabled && !!invalidFeedback;
+    // Invalid feedback is tied to invalid state, independent of label visibility.
+    // Supporting text is replaced when feedback is shown.
+    const showInvalidFeedback = isInvalid && !!invalidFeedback;
     const footerText = showInvalidFeedback ? invalidFeedback : supportingText;
     const feedbackId = footerText ? `${id}-feedback` : undefined;
 
@@ -296,7 +299,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             }}
             {...textareaProps}
           />
-          {isInvalid && !disabled && (
+          {isInvalid && (
             /* circle-exclamation icon: invalid state must not rely on colour alone (WCAG 1.4.1) */
             <i
               className="fa-solid fa-circle-exclamation mds-textarea-invalid-icon"


### PR DESCRIPTION
## Description

Disabled and read-only textareas should not display invalid styling, the invalid icon, or invalid feedback text — invalid is only ever a modifier on top of default/hover/active/focus per the design spec. Previously, isInvalid didn't account for disabled/readOnly, and the exclusion was instead scattered across individual usages (icon render, invalid feedback). This centralizes the exclusion into isInvalid itself and removes the now-redundant per-usage checks.

## Related Jira or GitHub Issue

https://moodle.atlassian.net/browse/MDS-641

## Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Screenshots/Previews

<img width="703" height="421" alt="Screenshot 2026-09-04 at 4 30 34 pm" src="https://github.com/user-attachments/assets/76f1e7db-3109-445d-9c16-c2e7926222c6" />

## Checklist

- [x] I have updated, added, and run tests such as JSUnit, Storybook interactions, or fuzzing to prove my fix is effective or that my feature works
- [x] I have updated or added Storybook stories for new or changed components (if appropriate)
- [x] I have considered accessibility and described any improvements or issues
- [x] I have considered security implications and referenced [SECURITY.md](./SECURITY.md) if relevant
- [x] Breaking change assessment complete — no prop, export, or token removed/renamed without a major version bump
- [x] Instruction files updated if this change introduces new patterns or anti-patterns

## Additional Notes

No new test/Storybook coverage was added for the disabled/readOnly + invalid interaction — worth adding before merge. No accessibility regressions: the invalid icon/aria-invalid are simply suppressed in these states, consistent with the WCAG 1.4.1 handling already in place. No security implications. No public API changes.
